### PR TITLE
PolicyMixture: combining different (stochastic) policies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,12 @@ commands:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
+      - run:
+          name: install evaluating_rewards
+          command: |
+            python setup.py sdist bdist_wheel
+            pip install dist/evaluating_rewards-*.whl
+
 jobs:
   lintandtype:
     executor: my-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,10 @@ commands:
 
       - run:
           name: install evaluating_rewards
+          # Build a wheel then install to avoid copying whole directory (pip issue #2195)
           command: |
             python setup.py sdist bdist_wheel
-            pip install dist/evaluating_rewards-*.whl
+            pip install --upgrade dist/evaluating_rewards-*.whl
 
 jobs:
   lintandtype:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
           # MUJOCO_KEY is defined in a CircleCI context
           # Do some sanity checks to make sure key works
           command: |
-            pip install -r requirements.txt -r requirements-dev.txt
+            pip install --upgrade -r requirements.txt -r requirements-dev.txt
             curl -o /root/.mujoco/mjkey.txt ${MUJOCO_KEY}
             md5sum /root/.mujoco/mjkey.txt
             python -c "import mujoco_py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 absl-py
 gym
-imitation @ git+https://github.com/HumanCompatibleAI/imitation.git
+imitation @ git+https://github.com/HumanCompatibleAI/imitation.git@a6faef8
 matplotlib
 mujoco_py
 numpy

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
     version=src.evaluating_rewards.__version__,
     description="Evaluating and comparing reward models.",
     author="DeepMind Technologies Limited and Adam Gleave",
+    author_email="adam@gleave.me",
     python_requires=">=3.6.0",
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -1,4 +1,4 @@
-# Copyright 2019 DeepMind Technologies Limited
+# Copyright 2019 DeepMind Technologies Limited and Adam Gleave
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ can be taken with respect to.
 
 import contextlib
 import math
-from typing import Callable, ContextManager, Iterator, Union
+from typing import Callable, ContextManager, Iterable, Iterator, Union
 
 import gym
 from imitation.policies import serialize
@@ -113,3 +113,106 @@ def random_transition_generator(env_name: str, seed: int = 0) -> Iterator[BatchC
             )
 
     yield f
+
+
+def _validate_policies(pola: policies.BasePolicy, polb: policies.BasePolicy, idx: int) -> None:
+    """Checks policies have consistent fields."""
+    fields = ["ob_space", "ac_space", "n_env", "n_batch", "n_steps"]
+    wildcard_fields = ["n_env", "n_batch", "n_steps"]
+    for f in fields:
+        pola_val = getattr(pola, f)
+        polb_val = getattr(polb, f)
+        different = pola_val != polb_val
+        either_none = pola_val is None or polb_val is None  # None indicates indifference
+        is_wildcard = f in wildcard_fields
+        if different and not (either_none and is_wildcard):
+            raise ValueError(
+                f"Inconsistent value for '{f}': '{pola_val}' at 0" f" != '{polb_val}' at {idx}"
+            )
+
+
+class PolicyMixture(policies.BasePolicy):
+    """Creates a stochastic policy from a mixture of policies.
+
+    WARNING: The resulting policy is only suitable for inference and not training.
+    """
+
+    def __init__(
+        self, pols: Iterable[policies.BasePolicy], transition_p: float = 0.1, seed: int = 0
+    ):  # pylint:disable=super-init-not-called
+        """Constructs a PolicyMixture.
+
+        Arguments:
+            pols: Policies to sample from.
+            transition_p: The probability of, at any given time step, switching from one
+                policy to another.
+            seed: Seed for the internal random generator, choosing when to switch between policies
+                and which policy to switch to.
+
+        Raises:
+              ValueError if policies is empty, or the policies have inconsistent attributes.
+              ValueError if transition_p is not a probability.
+        """
+        self.policies = list(pols)
+        if not self.policies:
+            raise ValueError("policies must be non-empty.")
+        a_policy = self.policies[0]
+        for idx, pol in enumerate(self.policies[1:]):
+            _validate_policies(a_policy, pol, idx)
+
+        # Set attributes expected of a policy. Do not call super() since that creates placeholders
+        # which we do not want (and are only needed for training.)
+        self.sess = None
+        self.ob_space = a_policy.ob_space
+        self.ac_space = a_policy.ac_space
+        self.n_env = a_policy.n_env
+        self.n_steps = a_policy.n_steps
+        self.n_batch = a_policy.n_batch
+
+        # Randomly choose between policies
+        self.transition_p = transition_p
+        if not 0 <= self.transition_p <= 1:
+            raise ValueError(f"Probability transition_p = {transition_p} must be in [0,1].")
+        self.rng = np.random.RandomState(seed)
+        self.current_pol = self.rng.choice(self.policies)
+
+    def _maybe_change_pol(self):
+        if self.rng.uniform() < self.transition_p:
+            self.current_pol = self.rng.choice(self.policies)
+
+    def step(self, obs, state=None, mask=None, **kwargs):
+        self._maybe_change_pol()
+        return self.current_pol.step(obs, state=state, mask=mask, **kwargs)
+
+    def proba_step(self, obs, state=None, mask=None, **kwargs):
+        self._maybe_change_pol()
+        return self.current_pol.proba_step(obs, state=state, mask=mask, **kwargs)
+
+
+@contextlib.contextmanager
+def load_mixture(policy_path: str, venv: vec_env.VecEnv) -> Iterator[policies.BasePolicy]:
+    """Load a mixed policy.
+
+    Arguments:
+        policy_path: A ':'-separated string, the first argument of which is `transition_p`, the
+            probability of switching policy at each timestep; the remaining arguments are pairs of
+            policy_type and policy_type that are used to load additional policies.
+        venv: An environment that the policy is to be used with.
+    """
+    transition_p, *pol_args = policy_path.split(":")
+    transition_p = float(transition_p)
+    pol_types = pol_args[::2]
+    pol_paths = pol_args[1::2]
+    if len(pol_types) != len(pol_paths):
+        raise ValueError(f"Malformed policy_path, missing policy path after type: '{policy_path}'")
+
+    with contextlib.ExitStack() as stack:
+        pols = [
+            stack.enter_context(serialize.load_policy(inner_type, inner_path, venv))
+            for inner_type, inner_path in zip(pol_types, pol_paths)
+        ]
+        mixture = PolicyMixture(pols, transition_p=transition_p)
+        yield mixture
+
+
+serialize.policy_registry.register("mixture", value=load_mixture)

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -1,4 +1,4 @@
-# Copyright 2019 DeepMind Technologies Limited and Adam Gleave
+# Copyright 2019 DeepMind Technologies Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ can be taken with respect to.
 
 import contextlib
 import math
-from typing import Callable, ContextManager, Iterable, Iterator, Union
+from typing import Callable, ContextManager, Iterator, Union
 
 import gym
 from imitation.policies import serialize
@@ -113,106 +113,3 @@ def random_transition_generator(env_name: str, seed: int = 0) -> Iterator[BatchC
             )
 
     yield f
-
-
-def _validate_policies(pola: policies.BasePolicy, polb: policies.BasePolicy, idx: int) -> None:
-    """Checks policies have consistent fields."""
-    fields = ["ob_space", "ac_space", "n_env", "n_batch", "n_steps"]
-    wildcard_fields = ["n_env", "n_batch", "n_steps"]
-    for f in fields:
-        pola_val = getattr(pola, f)
-        polb_val = getattr(polb, f)
-        different = pola_val != polb_val
-        either_none = pola_val is None or polb_val is None  # None indicates indifference
-        is_wildcard = f in wildcard_fields
-        if different and not (either_none and is_wildcard):
-            raise ValueError(
-                f"Inconsistent value for '{f}': '{pola_val}' at 0" f" != '{polb_val}' at {idx}"
-            )
-
-
-class PolicyMixture(policies.BasePolicy):
-    """Creates a stochastic policy from a mixture of policies.
-
-    WARNING: The resulting policy is only suitable for inference and not training.
-    """
-
-    def __init__(
-        self, pols: Iterable[policies.BasePolicy], transition_p: float = 0.1, seed: int = 0
-    ):  # pylint:disable=super-init-not-called
-        """Constructs a PolicyMixture.
-
-        Arguments:
-            pols: Policies to sample from.
-            transition_p: The probability of, at any given time step, switching from one
-                policy to another.
-            seed: Seed for the internal random generator, choosing when to switch between policies
-                and which policy to switch to.
-
-        Raises:
-              ValueError if policies is empty, or the policies have inconsistent attributes.
-              ValueError if transition_p is not a probability.
-        """
-        self.policies = list(pols)
-        if not self.policies:
-            raise ValueError("policies must be non-empty.")
-        a_policy = self.policies[0]
-        for idx, pol in enumerate(self.policies[1:]):
-            _validate_policies(a_policy, pol, idx)
-
-        # Set attributes expected of a policy. Do not call super() since that creates placeholders
-        # which we do not want (and are only needed for training.)
-        self.sess = None
-        self.ob_space = a_policy.ob_space
-        self.ac_space = a_policy.ac_space
-        self.n_env = a_policy.n_env
-        self.n_steps = a_policy.n_steps
-        self.n_batch = a_policy.n_batch
-
-        # Randomly choose between policies
-        self.transition_p = transition_p
-        if not 0 <= self.transition_p <= 1:
-            raise ValueError(f"Probability transition_p = {transition_p} must be in [0,1].")
-        self.rng = np.random.RandomState(seed)
-        self.current_pol = self.rng.choice(self.policies)
-
-    def _maybe_change_pol(self):
-        if self.rng.uniform() < self.transition_p:
-            self.current_pol = self.rng.choice(self.policies)
-
-    def step(self, obs, state=None, mask=None, **kwargs):
-        self._maybe_change_pol()
-        return self.current_pol.step(obs, state=state, mask=mask, **kwargs)
-
-    def proba_step(self, obs, state=None, mask=None, **kwargs):
-        self._maybe_change_pol()
-        return self.current_pol.proba_step(obs, state=state, mask=mask, **kwargs)
-
-
-@contextlib.contextmanager
-def load_mixture(policy_path: str, venv: vec_env.VecEnv) -> Iterator[policies.BasePolicy]:
-    """Load a mixed policy.
-
-    Arguments:
-        policy_path: A ':'-separated string, the first argument of which is `transition_p`, the
-            probability of switching policy at each timestep; the remaining arguments are pairs of
-            policy_type and policy_type that are used to load additional policies.
-        venv: An environment that the policy is to be used with.
-    """
-    transition_p, *pol_args = policy_path.split(":")
-    transition_p = float(transition_p)
-    pol_types = pol_args[::2]
-    pol_paths = pol_args[1::2]
-    if len(pol_types) != len(pol_paths):
-        raise ValueError(f"Malformed policy_path, missing policy path after type: '{policy_path}'")
-
-    with contextlib.ExitStack() as stack:
-        pols = [
-            stack.enter_context(serialize.load_policy(inner_type, inner_path, venv))
-            for inner_type, inner_path in zip(pol_types, pol_paths)
-        ]
-        mixture = PolicyMixture(pols, transition_p=transition_p)
-        yield mixture
-
-
-serialize.policy_registry.register("mixture", value=load_mixture)

--- a/src/evaluating_rewards/envs/mujoco.py
+++ b/src/evaluating_rewards/envs/mujoco.py
@@ -249,7 +249,7 @@ class HopperBackflipReward(MujocoHardcodedReward):
 
 
 class PointMazeReward(MujocoHardcodedReward):
-    """Reward for imitation/PointMaze{Left,Right}-v0.
+    """Reward for imitation/PointMaze{Left,Right}Vel-v0.
 
     This in turn is based on on Fu et al (2018)'s PointMaze environment:
     https://arxiv.org/pdf/1710.11248.pdf
@@ -290,9 +290,9 @@ class PointMazeReward(MujocoHardcodedReward):
         Returns:
             A tensor containing reward, shape (batch_size,).
         """
-        assert self.observation_space.shape == (3,)
-        particle = self._proc_obs[:, 0:3]
-        reward_dist = tf.norm(particle - self.target, axis=-1)
+        assert self.observation_space.shape == (6,)
+        particle_pos = self._proc_obs[:, 0:3]  # 3:6 is velocity
+        reward_dist = tf.norm(particle_pos - self.target, axis=-1)
         reward_ctrl = tf.reduce_sum(tf.square(self._proc_act), axis=-1)
         reward = -reward_dist - self.ctrl_coef * reward_ctrl
         return reward

--- a/src/evaluating_rewards/envs/mujoco.py
+++ b/src/evaluating_rewards/envs/mujoco.py
@@ -290,7 +290,8 @@ class PointMazeReward(MujocoHardcodedReward):
         Returns:
             A tensor containing reward, shape (batch_size,).
         """
-        assert self.observation_space.shape == (6,)
+        # Two versions, one without velocity (3,) and one with velocity (6,)
+        assert self.observation_space.shape in [(3,), (6,)]
         particle_pos = self._proc_obs[:, 0:3]  # 3:6 is velocity
         reward_dist = tf.norm(particle_pos - self.target, axis=-1)
         reward_ctrl = tf.reduce_sum(tf.square(self._proc_act), axis=-1)

--- a/src/evaluating_rewards/envs/point_mass.py
+++ b/src/evaluating_rewards/envs/point_mass.py
@@ -103,7 +103,7 @@ class PointMassEnv(resettable_env.ResettableEnv):
 
     def render(self, mode="human"):
         if self.viewer is None:
-            from gym.envs.classic_control import rendering
+            from gym.envs.classic_control import rendering  # pylint:disable=import-outside-toplevel
 
             self.viewer = rendering.Viewer(500, 500)
             self.viewer.set_bounds(-5, 5, -5, 5)

--- a/src/evaluating_rewards/experiments/comparisons.py
+++ b/src/evaluating_rewards/experiments/comparisons.py
@@ -21,8 +21,7 @@ from typing import Any, Dict
 
 import numpy as np
 
-from evaluating_rewards import comparisons, rewards
-from evaluating_rewards.experiments import datasets
+from evaluating_rewards import comparisons, datasets, rewards
 
 
 def norm_diff(predicted: np.ndarray, actual: np.ndarray, norm: int):

--- a/src/evaluating_rewards/experiments/env_rewards.py
+++ b/src/evaluating_rewards/experiments/env_rewards.py
@@ -23,8 +23,8 @@ REWARDS_BY_ENV = {
     "evaluating_rewards/HalfCheetah-v3": ["evaluating_rewards/HalfCheetahGroundTruth.*-v0"],
     "evaluating_rewards/Hopper-v3": ["evaluating_rewards/Hopper.*-v0"],
     "evaluating_rewards/PointMassLine-v0": ["evaluating_rewards/PointMass.*-v0"],
-    "imitation/PointMazeLeft-v0": ["evaluating_rewards/PointMaze.*-v0"],
-    "imitation/PointMazeRight-v0": ["evaluating_rewards/PointMaze.*-v0"],
+    "imitation/PointMazeLeftVel-v0": ["evaluating_rewards/PointMaze.*-v0"],
+    "imitation/PointMazeRightVel-v0": ["evaluating_rewards/PointMaze.*-v0"],
 }
 GENERIC_REWARDS = ["evaluating_rewards/Zero-v0"]
 for env_name in REWARDS_BY_ENV:

--- a/src/evaluating_rewards/experiments/point_mass_analysis.py
+++ b/src/evaluating_rewards/experiments/point_mass_analysis.py
@@ -25,9 +25,8 @@ import numpy as np
 import seaborn as sns
 import xarray
 
-from evaluating_rewards import rewards
+from evaluating_rewards import datasets, rewards
 from evaluating_rewards.envs import point_mass
-from evaluating_rewards.experiments import datasets
 
 
 def plot_reward(rew: xarray.DataArray, cmap: str = "RdBu", **kwargs) -> plt.Figure:

--- a/src/evaluating_rewards/experiments/synthetic.py
+++ b/src/evaluating_rewards/experiments/synthetic.py
@@ -27,8 +27,7 @@ import pandas as pd
 import scipy as sp
 import tensorflow as tf
 
-from evaluating_rewards import comparisons, rewards
-from evaluating_rewards.experiments import datasets
+from evaluating_rewards import comparisons, datasets, rewards
 
 TensorCallable = Callable[..., tf.Tensor]
 

--- a/src/evaluating_rewards/policies.py
+++ b/src/evaluating_rewards/policies.py
@@ -1,0 +1,125 @@
+# Copyright 2019 Adam Gleave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#            http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom policies and policy wrappers."""
+
+import contextlib
+from typing import Iterable, Iterator
+
+from imitation.policies import serialize
+import numpy as np
+from stable_baselines.common import policies, vec_env
+
+
+def _validate_policies(pola: policies.BasePolicy, polb: policies.BasePolicy, idx: int) -> None:
+    """Checks policies have consistent fields."""
+    fields = ["ob_space", "ac_space", "n_env", "n_batch", "n_steps"]
+    wildcard_fields = ["n_env", "n_batch", "n_steps"]
+    for f in fields:
+        pola_val = getattr(pola, f)
+        polb_val = getattr(polb, f)
+        different = pola_val != polb_val
+        either_none = pola_val is None or polb_val is None  # None indicates indifference
+        is_wildcard = f in wildcard_fields
+        if different and not (either_none and is_wildcard):
+            raise ValueError(
+                f"Inconsistent value for '{f}': '{pola_val}' at 0" f" != '{polb_val}' at {idx}"
+            )
+
+
+class PolicyMixture(policies.BasePolicy):
+    """Creates a stochastic policy from a mixture of policies.
+
+    WARNING: The resulting policy is only suitable for inference and not training.
+    """
+
+    def __init__(
+        self, pols: Iterable[policies.BasePolicy], transition_p: float = 0.1, seed: int = 0
+    ):  # pylint:disable=super-init-not-called
+        """Constructs a PolicyMixture.
+
+        Arguments:
+            pols: Policies to sample from.
+            transition_p: The probability of, at any given time step, switching from one
+                policy to another.
+            seed: Seed for the internal random generator, choosing when to switch between policies
+                and which policy to switch to.
+
+        Raises:
+              ValueError if policies is empty, or the policies have inconsistent attributes.
+              ValueError if transition_p is not a probability.
+        """
+        self.policies = list(pols)
+        if not self.policies:
+            raise ValueError("policies must be non-empty.")
+        a_policy = self.policies[0]
+        for idx, pol in enumerate(self.policies[1:]):
+            _validate_policies(a_policy, pol, idx)
+
+        # Set attributes expected of a policy. Do not call super() since that creates placeholders
+        # which we do not want (and are only needed for training.)
+        self.sess = None
+        self.ob_space = a_policy.ob_space
+        self.ac_space = a_policy.ac_space
+        self.n_env = a_policy.n_env
+        self.n_steps = a_policy.n_steps
+        self.n_batch = a_policy.n_batch
+
+        # Randomly choose between policies
+        self.transition_p = transition_p
+        if not 0 <= self.transition_p <= 1:
+            raise ValueError(f"Probability transition_p = {transition_p} must be in [0,1].")
+        self.rng = np.random.RandomState(seed)
+        self.current_pol = self.rng.choice(self.policies)
+
+    def _maybe_change_pol(self):
+        if self.rng.uniform() < self.transition_p:
+            self.current_pol = self.rng.choice(self.policies)
+
+    def step(self, obs, state=None, mask=None, **kwargs):
+        self._maybe_change_pol()
+        return self.current_pol.step(obs, state=state, mask=mask, **kwargs)
+
+    def proba_step(self, obs, state=None, mask=None, **kwargs):
+        self._maybe_change_pol()
+        return self.current_pol.proba_step(obs, state=state, mask=mask, **kwargs)
+
+
+@contextlib.contextmanager
+def load_mixture(policy_path: str, venv: vec_env.VecEnv) -> Iterator[policies.BasePolicy]:
+    """Load a mixed policy.
+
+    Arguments:
+        policy_path: A ':'-separated string, the first argument of which is `transition_p`, the
+            probability of switching policy at each timestep; the remaining arguments are pairs of
+            policy_type and policy_type that are used to load additional policies.
+        venv: An environment that the policy is to be used with.
+    """
+    transition_p, *pol_args = policy_path.split(":")
+    transition_p = float(transition_p)
+    pol_types = pol_args[::2]
+    pol_paths = pol_args[1::2]
+    if len(pol_types) != len(pol_paths):
+        raise ValueError(f"Malformed policy_path, missing policy path after type: '{policy_path}'")
+
+    with contextlib.ExitStack() as stack:
+        pols = [
+            stack.enter_context(serialize.load_policy(inner_type, inner_path, venv))
+            for inner_type, inner_path in zip(pol_types, pol_paths)
+        ]
+        mixture = PolicyMixture(pols, transition_p=transition_p)
+        yield mixture
+
+
+serialize.policy_registry.register("mixture", value=load_mixture)

--- a/src/evaluating_rewards/scripts/eval_policy.py
+++ b/src/evaluating_rewards/scripts/eval_policy.py
@@ -14,10 +14,11 @@
 
 """Thin wrapper around imitation.scripts.eval_policy."""
 
-# Imported for side-effect (registers policy with imitation)
 from absl import app
-from imitation.scripts import eval_policy  # pylint: disable=unused-import
+from imitation.scripts import eval_policy
 
+# Imported for side-effect (registers policies we may want to use)
+from evaluating_rewards import policies  # pylint:disable=unused-import # noqa: F401
 from evaluating_rewards.scripts import script_utils
 
 if __name__ == "__main__":

--- a/src/evaluating_rewards/scripts/model_comparison.py
+++ b/src/evaluating_rewards/scripts/model_comparison.py
@@ -22,8 +22,7 @@ from absl import app
 import sacred
 import tensorflow as tf
 
-from evaluating_rewards import comparisons, serialize
-from evaluating_rewards.experiments import datasets
+from evaluating_rewards import comparisons, datasets, serialize
 from evaluating_rewards.scripts import regress_utils, script_utils
 
 model_comparison_ex = sacred.Experiment("model_comparison")

--- a/src/evaluating_rewards/scripts/train_regress.py
+++ b/src/evaluating_rewards/scripts/train_regress.py
@@ -20,8 +20,7 @@ from typing import Any, Dict, Mapping
 from absl import app
 import sacred
 
-from evaluating_rewards import comparisons, rewards
-from evaluating_rewards.experiments import datasets
+from evaluating_rewards import comparisons, datasets, rewards
 from evaluating_rewards.scripts import regress_utils, script_utils
 
 train_regress_ex = sacred.Experiment("train_regress")

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -22,9 +22,7 @@ from stable_baselines.common import vec_env
 import tensorflow as tf
 
 # Environments registered as a side-effect of importing
-from evaluating_rewards import comparisons, rewards, serialize
-from evaluating_rewards import envs  # noqa: F401 pylint:disable=unused-import
-from evaluating_rewards.experiments import datasets
+from evaluating_rewards import comparisons, datasets, rewards, serialize
 from tests import common
 
 PM_REWARD_TYPES = {

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,96 @@
+# Copyright 2019 Adam Gleave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for evaluating_rewards.datasets."""
+
+from typing import Sequence, Set, Tuple
+
+import gym
+from imitation.policies import base
+import numpy as np
+import pytest
+
+from evaluating_rewards import datasets
+
+
+class FixedPolicy(base.HardCodedPolicy):  # pylint:disable=abstract-method
+    """Policy that always returns a fixed value."""
+
+    def __init__(self, ob_space: gym.Space, ac_space: gym.Space, fixed_val: np.ndarray):
+        super().__init__(ob_space, ac_space)
+        self.fixed_val = fixed_val
+        if not ac_space.contains(fixed_val):
+            raise ValueError(f"fixed_val = '{fixed_val}' not contained in ac_space = '{ac_space}'")
+
+    def _choose_action(self, obs: np.ndarray) -> np.ndarray:
+        return self.fixed_val
+
+
+def test_policy_mixture_validation():
+    """Test input validation."""
+    with pytest.raises(ValueError):
+        datasets.PolicyMixture(pols=[])
+
+    space1 = gym.spaces.Box(low=0, high=1, shape=(2,))
+    space2 = gym.spaces.Box(low=0, high=1, shape=(3,))
+    space3 = gym.spaces.Box(low=0, high=0.5, shape=(2,))
+
+    with pytest.raises(ValueError):
+        datasets.PolicyMixture(
+            pols=[
+                FixedPolicy(space1, space1, [0.5, 0.5]),
+                FixedPolicy(space2, space2, [0.5, 0.5, 0.5]),
+            ]
+        )
+
+    with pytest.raises(ValueError):
+        datasets.PolicyMixture(
+            pols=[FixedPolicy(space1, space1, [0.5, 0.5]), FixedPolicy(space2, space3, [0.5, 0.5])]
+        )
+
+
+def _test_policy_mixture(
+    n_policies: int, transition_p: float, n_steps: int, batch_size: int
+) -> Tuple[Sequence[np.ndarray], Set[np.ndarray]]:
+    space = gym.spaces.Box(low=0, high=1, shape=(2,))
+    fixed_vals = np.array([space.sample() for _ in range(n_policies)])
+    policies = [FixedPolicy(space, space, fixed_val) for fixed_val in fixed_vals]
+    mixture = datasets.PolicyMixture(pols=policies, transition_p=transition_p)
+
+    actions = []
+    for _ in range(n_steps):
+        obs = np.array([space.sample() for _ in range(batch_size)])
+        action, _, _, _ = mixture.step(obs)
+        assert action.shape[0] == batch_size
+        action = np.unique(action, axis=0)
+        assert action.shape[0] == 1
+        action = action[0, :]
+        assert action in fixed_vals
+        actions.append(action)
+
+    return fixed_vals, np.unique(actions, axis=0)
+
+
+def test_policy_mixture():
+    """Test returned values are plausible."""
+    fixed_vals, seen = _test_policy_mixture(
+        n_policies=3, transition_p=0.5, n_steps=100, batch_size=4
+    )
+    assert np.all(np.sort(seen, axis=0) == np.sort(fixed_vals, axis=0))
+
+
+def test_policy_mixture_never_change():
+    """If transition_p is zero, policy should never switch."""
+    _, seen = _test_policy_mixture(n_policies=2, transition_p=0.0, n_steps=100, batch_size=4)
+    assert seen.shape[0] == 1

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for evaluating_rewards.datasets."""
+"""Unit tests for evaluating_rewards.policies."""
 
 from typing import Sequence, Set, Tuple
 
@@ -21,7 +21,7 @@ from imitation.policies import base
 import numpy as np
 import pytest
 
-from evaluating_rewards import datasets
+from evaluating_rewards import policies
 
 
 class FixedPolicy(base.HardCodedPolicy):  # pylint:disable=abstract-method
@@ -40,14 +40,14 @@ class FixedPolicy(base.HardCodedPolicy):  # pylint:disable=abstract-method
 def test_policy_mixture_validation():
     """Test input validation."""
     with pytest.raises(ValueError):
-        datasets.PolicyMixture(pols=[])
+        policies.PolicyMixture(pols=[])
 
     space1 = gym.spaces.Box(low=0, high=1, shape=(2,))
     space2 = gym.spaces.Box(low=0, high=1, shape=(3,))
     space3 = gym.spaces.Box(low=0, high=0.5, shape=(2,))
 
     with pytest.raises(ValueError):
-        datasets.PolicyMixture(
+        policies.PolicyMixture(
             pols=[
                 FixedPolicy(space1, space1, [0.5, 0.5]),
                 FixedPolicy(space2, space2, [0.5, 0.5, 0.5]),
@@ -55,7 +55,7 @@ def test_policy_mixture_validation():
         )
 
     with pytest.raises(ValueError):
-        datasets.PolicyMixture(
+        policies.PolicyMixture(
             pols=[FixedPolicy(space1, space1, [0.5, 0.5]), FixedPolicy(space2, space3, [0.5, 0.5])]
         )
 
@@ -65,8 +65,8 @@ def _test_policy_mixture(
 ) -> Tuple[Sequence[np.ndarray], Set[np.ndarray]]:
     space = gym.spaces.Box(low=0, high=1, shape=(2,))
     fixed_vals = np.array([space.sample() for _ in range(n_policies)])
-    policies = [FixedPolicy(space, space, fixed_val) for fixed_val in fixed_vals]
-    mixture = datasets.PolicyMixture(pols=policies, transition_p=transition_p)
+    pols = [FixedPolicy(space, space, fixed_val) for fixed_val in fixed_vals]
+    mixture = policies.PolicyMixture(pols=pols, transition_p=transition_p)
 
     actions = []
     for _ in range(n_steps):

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -24,9 +24,8 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from evaluating_rewards import rewards, serialize
+from evaluating_rewards import datasets, rewards, serialize
 from evaluating_rewards.envs import mujoco, point_mass
-from evaluating_rewards.experiments import datasets
 from tests import common
 
 ENVS = ["FrozenLake-v0", "CartPole-v1", "Pendulum-v0"]

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -47,7 +47,7 @@ STANDALONE_REWARD_MODELS = {
         "kwargs": {},
     },
     "point_maze_ground_truth": {
-        "env_name": "imitation/PointMazeLeft-v0",
+        "env_name": "imitation/PointMazeLeftVel-v0",
         "model_class": mujoco.PointMazeReward,
         "kwargs": {"target": np.array([0.3, 0.3, 0])},
     },
@@ -91,7 +91,7 @@ GROUND_TRUTH = {
         "evaluating_rewards/HopperGroundTruthForwardWithCtrl-v0",
     ),
     "point_maze": (
-        "imitation/PointMazeLeft-v0",
+        "imitation/PointMazeLeftVel-v0",
         "evaluating_rewards/PointMazeGroundTruthWithCtrl-v0",
     ),
 }

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -28,9 +28,9 @@ import pandas as pd
 import pytest
 import tensorflow as tf
 
-from evaluating_rewards import rewards
+from evaluating_rewards import datasets, rewards
 from evaluating_rewards.envs import point_mass
-from evaluating_rewards.experiments import datasets, synthetic
+from evaluating_rewards.experiments import synthetic
 from tests import common
 
 


### PR DESCRIPTION
This PR adds a new class `PolicyMixture`, registered as policy type `mixture`, which supports combining multiple policies for inference.

The use case that inspired this is combining an expert policy with a random policy, to get something that achieves good state coverage.