### PR TITLE
Simplify Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ orbs:
 executors:
   my-executor:
     docker:
-      - image: humancompatibleai/evaluating_rewards:latest
+      - image: humancompatibleai/evaluating_rewards:base
     working_directory: /evaluating-rewards
     environment:
       # If you change these, also change scripts/code_checks.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,24 +39,22 @@ commands:
       # binary (non-Python) dependencies change.
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: install dependencies
           # MUJOCO_KEY is defined in a CircleCI context
           # Do some sanity checks to make sure key works
           command: |
-            pip install --upgrade -r requirements.txt -r requirements-dev.txt
             curl -o /root/.mujoco/mjkey.txt ${MUJOCO_KEY}
             md5sum /root/.mujoco/mjkey.txt
+            [[ -d /venv ]] || /evaluating-rewards/scripts/build_venv.sh /venv
             python -c "import mujoco_py"
 
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+            - /venv
+          key: v2-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: install evaluating_rewards
@@ -100,7 +98,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            pytest --cov=venv/lib/python3.7/site-packages/evaluating_rewards --cov=tests \
+            pytest --cov=/venv/lib/python3.7/site-packages/evaluating_rewards --cov=tests \
                    --junitxml=/tmp/test-reports/junit.xml --no-success-flaky-report \
                    --shard-id=${CIRCLE_NODE_INDEX} --num-shards=${CIRCLE_NODE_TOTAL} \
                     -n ${NUM_CPUS} -vv tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN    apt-get update -q \
     software-properties-common \
     net-tools \
     parallel \
+    python3.7 \
+    python3.7-dev \
     rsync \
     unzip \
     vim \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-gym
+gym[mujoco]
 imitation @ git+https://github.com/HumanCompatibleAI/imitation.git@a6faef8
 matplotlib
-mujoco_py
 numpy
 pandas
 seaborn

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -30,7 +30,7 @@ class FixedPolicy(base.HardCodedPolicy):  # pylint:disable=abstract-method
     def __init__(self, ob_space: gym.Space, ac_space: gym.Space, fixed_val: np.ndarray):
         super().__init__(ob_space, ac_space)
         self.fixed_val = fixed_val
-        if not ac_space.contains(fixed_val):
+        if not ac_space.contains(fixed_val):  # pragma: no cover
             raise ValueError(f"fixed_val = '{fixed_val}' not contained in ac_space = '{ac_space}'")
 
     def _choose_action(self, obs: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
  - Split Dockerfile into stages.
  - CI now uses base stage, which excludes `venv`, so as not to duplicate venv given CircleCI caching.
  - Downgrade from MuJoCo 2.0 to 1.5 (needed for recent Gym versions).
