### PR TITLE
Script to create double-blind version of source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Source code for paper submission
+supplementary.zip

--- a/scripts/doubleblind.sh
+++ b/scripts/doubleblind.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$( dirname "${SCRIPT_DIR}" )"
+
+OPTIONS="-v -z -r -lpt"
+EXCLUDES="LICENSE README.md CONTRIBUTING.md setup.py scripts/ .circleci/ notebooks/ runners/launch_docker.sh tests/data/ .git *.pkl"
+
+# Refuse to compile if we find any of these words in non-excluded sources
+# Adam(^|[^O]): excludes my name (Adam), but not AdamOptimizer
+BLACKLISTED="Adam(^|[^O]) Gleave Leike Shane Legg Stuart Russell berkeley humancompatibleai humancompatible deepmind Google"
+
+TMPDIR=`mktemp --tmpdir -d doubleblinded.XXXXXXXX`
+
+SYNC_CMD="rsync ${OPTIONS} --exclude-from=.gitignore"
+for exclude in ${EXCLUDES}; do
+  SYNC_CMD="${SYNC_CMD} --exclude=${exclude}"
+done
+
+${SYNC_CMD} ${ROOT_DIR} ${TMPDIR}
+pushd ${TMPDIR}
+
+find . -type f | xargs -n 1 sed -i 's/# Copyright .*/# Copyright Anonymous Authors/'
+find . -name '*.py' | xargs -n 1 sed -i 's/.*# TODO(.*).*//'
+
+GREP_TERMS=""
+for pattern in ${BLACKLISTED}; do
+  GREP_TERMS="${GREP_TERMS} -e ${pattern}"
+done
+grep -r . -i -E ${GREP_TERMS}
+if [[ $? -ne 1 ]]; then
+  echo "Found blacklisted word. Dieing."
+  exit 1
+fi
+
+rm ${ROOT_DIR}/supplementary.zip
+zip -r ${ROOT_DIR}/supplementary.zip .
+popd

--- a/scripts/doubleblind.sh
+++ b/scripts/doubleblind.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$( dirname "${SCRIPT_DIR}" )"
 
 OPTIONS="-v -z -r -lpt"
-EXCLUDES="LICENSE README.md CONTRIBUTING.md setup.py scripts/ .circleci/ notebooks/ runners/launch_docker.sh tests/data/ .git *.pkl"
+EXCLUDES="LICENSE README.md CONTRIBUTING.md setup.py scripts/ .circleci/ notebooks/ runners/launch_docker.sh tests/data/ .git *.pkl requirements*.txt"
 
 # Refuse to compile if we find any of these words in non-excluded sources
 # Adam(^|[^O]): excludes my name (Adam), but not AdamOptimizer


### PR DESCRIPTION
Required for many conference submissions.

Derivative of https://github.com/HumanCompatibleAI/adversarial-policies/blob/master/scripts/doubleblind.sh