### PR TITLE
Explicitly specify discount rate for reward models

### DIFF
--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -87,10 +87,13 @@ def test():
 
 
 def load_models(
-    env_name: str, reward_cfgs: Iterable[config.RewardCfg],
+    env_name: str, reward_cfgs: Iterable[config.RewardCfg], discount: float,
 ) -> Mapping[config.RewardCfg, rewards.RewardModel]:
     venv = vec_env.DummyVecEnv([lambda: gym.make(env_name)])
-    return {(kind, path): serialize.load_reward(kind, path, venv) for kind, path in reward_cfgs}
+    return {
+        (kind, path): serialize.load_reward(kind, path, venv, discount)
+        for kind, path in reward_cfgs
+    }
 
 
 def make_gym_dists(env_name: str) -> Tuple[datasets.SampleDist, datasets.SampleDist]:
@@ -235,6 +238,7 @@ def sample_canon(
 @plot_canon_heatmap_ex.main
 def plot_canon_heatmap(
     env_name: str,
+    discount: float,
     x_reward_cfgs: Iterable[config.RewardCfg],
     y_reward_cfgs: Iterable[config.RewardCfg],
     computation_kind: str,
@@ -268,7 +272,7 @@ def plot_canon_heatmap(
         sess = tf.Session()
         with sess.as_default():
             reward_cfgs = list(x_reward_cfgs) + list(y_reward_cfgs)
-            models = load_models(env_name, reward_cfgs)
+            models = load_models(env_name, reward_cfgs, discount)
 
     # TODO(adam): make distribution configurable
     obs_dist, act_dist = make_gym_dists(env_name)

--- a/src/evaluating_rewards/analysis/results.py
+++ b/src/evaluating_rewards/analysis/results.py
@@ -199,10 +199,7 @@ def get_affine_from_models(env_name: str, paths: Iterable[str]):
     with imitation_util.make_session():
         for path in paths:
             model = serialize.load_reward(
-                "evaluating_rewards/RewardModel-v0",
-                os.path.join(path, "model"),
-                venv,
-                discount=1.0,  # arbitrary; has no affect weights
+                "evaluating_rewards/RewardModel-v0", os.path.join(path, "model"), venv,
             )
             return model.models["wrapped"][0].get_weights()
     return res

--- a/src/evaluating_rewards/analysis/results.py
+++ b/src/evaluating_rewards/analysis/results.py
@@ -199,7 +199,10 @@ def get_affine_from_models(env_name: str, paths: Iterable[str]):
     with imitation_util.make_session():
         for path in paths:
             model = serialize.load_reward(
-                "evaluating_rewards/RewardModel-v0", os.path.join(path, "model"), venv
+                "evaluating_rewards/RewardModel-v0",
+                os.path.join(path, "model"),
+                venv,
+                discount=1.0,  # arbitrary; has no affect weights
             )
             return model.models["wrapped"][0].get_weights()
     return res

--- a/src/evaluating_rewards/analysis/reward_figures/plot_pm_reward.py
+++ b/src/evaluating_rewards/analysis/reward_figures/plot_pm_reward.py
@@ -40,6 +40,7 @@ def default_config():
     """Default configuration values."""
     # Reward parameters
     env_name = "evaluating_rewards/PointMassLine-v0"
+    discount = 0.99
     # Simple method: specify one model
     reward_type = "evaluating_rewards/PointMassSparseWithCtrl-v0"
     reward_path = "dummy"
@@ -130,6 +131,7 @@ def test():
 def plot_pm_reward(
     styles: Iterable[str],
     env_name: str,
+    discount: float,
     models: Sequence[Tuple[str, str, str]],
     data_root: str,
     # Mesh parameters
@@ -154,7 +156,7 @@ def plot_pm_reward(
         with util.make_session():
             for model_name, reward_type, reward_path in models:
                 reward_path = os.path.join(data_root, reward_path)
-                model = serialize.load_reward(reward_type, reward_path, venv)
+                model = serialize.load_reward(reward_type, reward_path, venv, discount)
                 reward = point_mass_analysis.evaluate_reward_model(
                     env,
                     model,

--- a/src/evaluating_rewards/experiments/monte_carlo.py
+++ b/src/evaluating_rewards/experiments/monte_carlo.py
@@ -117,8 +117,8 @@ class MonteCarloGreedyPolicy(policies.BasePolicy):
 
 @registry.sess_context
 def load_monte_carlo_greedy(path: str, env: vec_env.VecEnv) -> MonteCarloGreedyPolicy:
-    reward_type, reward_path = path.split(":")
-    reward_model = serialize.load_reward(reward_type, reward_path, env)
+    reward_type, reward_path, discount = path.split(":")
+    reward_model = serialize.load_reward(reward_type, reward_path, env, float(discount))
     return MonteCarloGreedyPolicy(env, reward_model=reward_model)
 
 

--- a/src/evaluating_rewards/rewards.py
+++ b/src/evaluating_rewards/rewards.py
@@ -72,13 +72,13 @@ class RewardModel(serialize.Serializable, abc.ABC):
     def discount(self) -> Optional[tf.Tensor]:
         """Tensor specifying discount rate of reward model, or None if not applicable.
 
-        Generally reward models that involve explicit shaping will have a discount parameters
-        but others will not.
+        Generally reward models that involve explicit shaping will have a discount parameter
+        while others will not.
         """
         return None
 
     def set_discount(self, discount: float) -> None:
-        """Set the discount rate; no-op in models where this is not applicable."""
+        """Set the discount rate; no-op in models without internal discounting."""
 
     @property
     @abc.abstractmethod

--- a/src/evaluating_rewards/rewards.py
+++ b/src/evaluating_rewards/rewards.py
@@ -69,6 +69,18 @@ class RewardModel(serialize.Serializable, abc.ABC):
         """Gets the reward output tensor."""
 
     @property
+    def discount(self) -> Optional[tf.Tensor]:
+        """Tensor specifying discount rate of reward model, or None if not applicable.
+
+        Generally reward models that involve explicit shaping will have a discount parameters
+        but others will not.
+        """
+        return None
+
+    def set_discount(self, discount: float) -> None:
+        """Set the discount rate; no-op in models where this is not applicable."""
+
+    @property
     @abc.abstractmethod
     def observation_space(self) -> gym.Space:
         """Gets the space of observations."""
@@ -193,14 +205,23 @@ class PotentialShaping(BasicRewardModel, serialize.LayersSerializable):
             hid_sizes, self._proc_obs, self._proc_next_obs, **kwargs
         )
         self._old_potential, self._new_potential, layers = res
-        self.discount = discount
-        self._reward_output = discount * self._new_potential - self.old_potential
+        self._discount = ConstantLayer("discount", initializer=tf.constant_initializer(discount))
+        self._discount.build(())
+        layers["discount"] = self._discount
+        self._reward_output = self.discount * self.new_potential - self.old_potential
 
         serialize.LayersSerializable.__init__(**params, layers=layers)
 
     @property
     def reward(self):
         return self._reward_output
+
+    @property
+    def discount(self) -> tf.Tensor:
+        return tf.stop_gradient(self._discount.constant)
+
+    def set_discount(self, discount: float) -> None:
+        self._discount.set_constant(discount)
 
     @property
     def old_potential(self):
@@ -324,6 +345,8 @@ class RewardNetToRewardModel(RewardModel):
         self.reward_net = network
         self.use_test = use_test
 
+    # SOMEDAY(adam): support discount/set_discount for RewardNetShaped
+
     @property
     def reward(self):
         net = self.reward_net
@@ -382,6 +405,13 @@ class RewardModelWrapper(RewardModel):
     @property
     def reward(self):
         return self.model.reward
+
+    @property
+    def discount(self):
+        return self.model.discount
+
+    def set_discount(self, discount):
+        return self.model.set_discount(discount)
 
     @property
     def observation_space(self):
@@ -447,6 +477,15 @@ class LinearCombinationModelWrapper(RewardModelWrapper):
     @property
     def reward(self):
         return self._reward_output
+
+    @property
+    def discount(self):
+        # SOMEDAY(adam): single representative is misleading, but can't do better with a scalar
+        return self.model.discount
+
+    def set_discount(self, discount):
+        for m, _ in self._models.values():
+            m.set_discount(discount)
 
     @property
     def obs_ph(self):

--- a/src/evaluating_rewards/scripts/model_comparison.py
+++ b/src/evaluating_rewards/scripts/model_comparison.py
@@ -155,6 +155,7 @@ def model_comparison(
     _seed: int,  # pylint:disable=invalid-name
     # Dataset
     env_name: str,
+    discount: float,
     dataset_factory: datasets.DatasetFactory,
     dataset_factory_kwargs: Dict[str, Any],
     # Source specification
@@ -177,7 +178,7 @@ def model_comparison(
     with dataset_factory(env_name, seed=_seed, **dataset_factory_kwargs) as dataset_generator:
 
         def make_source(venv):
-            return serialize.load_reward(source_reward_type, source_reward_path, venv)
+            return serialize.load_reward(source_reward_type, source_reward_path, venv, discount)
 
         def make_trainer(model, model_scope, target):
             del model_scope
@@ -196,6 +197,7 @@ def model_comparison(
         return regress_utils.regress(
             seed=_seed,
             env_name=env_name,
+            discount=discount,
             make_source=make_source,
             source_init=False,
             make_trainer=make_trainer,

--- a/src/evaluating_rewards/scripts/regress_utils.py
+++ b/src/evaluating_rewards/scripts/regress_utils.py
@@ -33,6 +33,7 @@ EnvRewardFactory = Callable[[gym.Space, gym.Space], rewards.RewardModel]
 
 DEFAULT_CONFIG = {
     "env_name": "evaluating_rewards/PointMassLine-v0",
+    "discount": 0.99,
     "target_reward_type": "evaluating_rewards/Zero-v0",
     "target_reward_path": "dummy",
     "model_reward_type": rewards.MLPRewardModel,
@@ -57,6 +58,7 @@ def make_model(model_reward_type: EnvRewardFactory, venv: vec_env.VecEnv) -> rew
 def regress(
     seed: int,
     env_name: str,
+    discount: float,
     make_source: MakeModelFn,
     source_init: bool,
     make_trainer: MakeTrainerFn,
@@ -76,7 +78,7 @@ def regress(
             model = make_source(venv)
 
         with tf.variable_scope("target"):
-            target = serialize.load_reward(target_reward_type, target_reward_path, venv)
+            target = serialize.load_reward(target_reward_type, target_reward_path, venv, discount)
 
         with tf.variable_scope("train") as train_scope:
             trainer = make_trainer(model, model_scope, target)

--- a/src/evaluating_rewards/scripts/train_preferences.py
+++ b/src/evaluating_rewards/scripts/train_preferences.py
@@ -67,6 +67,7 @@ def train_preferences(
     _seed: int,  # pylint:disable=invalid-name
     # Dataset
     env_name: str,
+    discount: float,
     num_vec: int,
     policy_type: str,
     policy_path: str,
@@ -122,6 +123,7 @@ def train_preferences(
         return regress_utils.regress(
             seed=_seed,
             env_name=env_name,
+            discount=discount,
             make_source=make_source,
             source_init=True,
             make_trainer=make_trainer,

--- a/src/evaluating_rewards/scripts/train_regress.py
+++ b/src/evaluating_rewards/scripts/train_regress.py
@@ -76,6 +76,7 @@ def train_regress(
     _seed: int,  # pylint:disable=invalid-name
     # Dataset
     env_name: str,
+    discount: float,
     dataset_factory: datasets.DatasetFactory,
     dataset_factory_kwargs: Dict[str, Any],
     # Target specification
@@ -106,6 +107,7 @@ def train_regress(
         return regress_utils.regress(
             seed=_seed,
             env_name=env_name,
+            discount=discount,
             make_source=make_source,
             source_init=True,
             make_trainer=make_trainer,

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -23,6 +23,7 @@ import tensorflow as tf
 
 # Environments registered as a side-effect of importing
 from evaluating_rewards import comparisons, datasets, rewards, serialize
+from evaluating_rewards import envs  # noqa: F401  pylint:disable=unused-import
 from tests import common
 
 PM_REWARD_TYPES = {
@@ -49,7 +50,12 @@ PM_REWARD_TYPES = {
 
 @common.mark_parametrize_kwargs(PM_REWARD_TYPES)
 def test_regress(
-    graph: tf.Graph, session: tf.Session, target: str, loss_ub: float, rel_loss_lb: float
+    graph: tf.Graph,
+    session: tf.Session,
+    target: str,
+    loss_ub: float,
+    rel_loss_lb: float,
+    discount: float = 0.99,
 ):
     """Test regression onto target.
 
@@ -69,7 +75,7 @@ def test_regress(
                     source = rewards.MLPRewardModel(venv.observation_space, venv.action_space)
 
                 with tf.variable_scope("target"):
-                    target_model = serialize.load_reward(target, "dummy", venv)
+                    target_model = serialize.load_reward(target, "dummy", venv, discount)
 
                 with tf.variable_scope("match") as match_scope:
                     match = comparisons.RegressModel(source, target_model)


### PR DESCRIPTION
Previously, the discount rate of potential shaping in reward models was specified on an ad-hoc basis, typically in the constructor arguments for relevant reward models. This was problematic for two reasons:
  1. Since there was no standard interface, experiments that depend on discount rate could not ensure it was set unifiormly amongst reward models.
  2. Furthermore, any model registered to be accessible with `serialize.load_reward` had a fixed discount rate.

This PR addresses this issue by adding a `discount` property and `set_discount` function to `RewardModel`, and adding a `discount` parameter to `load_reward`. It is backward compatible: the default implementations are no-ops, suitable for any reward model that does not include explicit shaping.

If I were to rearchitect this from scratch, I'd probably favour adding `discount` to the constructor arguments of `RewardModel`. This would not be *too* hard to do with the current code. Apart from changing the `RewardModel` classes, it would also require changing `evaluating_rewards.serialize`, and would break the API compatibility with `imitation` for serialization. Given this I'll punt this for some possibly-future rearchitect, e.g. if we ever merge this with `imitation` or switch to TF2/PyTorch.