### PR TITLE
Make state/action distribution configurable in `plot_canon_heatmap`

### DIFF
--- a/runners/comparison/hardcoded_canon.sh
+++ b/runners/comparison/hardcoded_canon.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright 2019 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compares hardcoded rewards to each other using CANON
+
+ENVS="point_mass hopper half_cheetah"
+DISCOUNTS="0.9 0.99 1.0"
+
+# Datasets?
+# Default: Sample from Gym, IID
+# Random policy, IID
+# Random policy, random batch
+# PointMass only: random transition, IID; random transition, random transition batch
+for env in ${ENVS}; do
+  for discount in ${DISCOUNTS}; do
+    for distance_kind in direct pearson; do
+      for computation_kind in sample mesh; do
+
+         BASE_CMD="python -m evaluating_rewards.analysis.dissimilarity_heatmaps.plot_canon_heatmap \
+                   with ${env} discount=${discount} distance_kind=${distance_kind} \
+                   computation_kind=${computation_kind}"
+
+         ${BASE_CMD}
+         ${BASE_CMD} sample_from_serialized_policy
+         ${BASE_CMD} sample_from_serialized_policy dataset_from_serialized_policy
+
+         if [[ ${env} == "point_mass" ]]; then
+           ${BASE_CMD} sample_from_random_transitions
+           ${BASE_CMD} sample_from_random_transitions dataset_from_random_transitions
+         fi
+      done;
+    done;
+  done;
+done

--- a/runners/comparison/hardcoded_canon.sh
+++ b/runners/comparison/hardcoded_canon.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2019 DeepMind Technologies Limited
+# Copyright 2020 Adam Gleave
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Compares hardcoded rewards to each other using CANON
+# Compares hardcoded rewards to each other using CANON: `plot_canon_heatmap.py`
 
 ENVS="point_mass hopper half_cheetah"
 DISCOUNTS="0.9 0.99 1.0"
 
-# Datasets?
-# Default: Sample from Gym, IID
-# Random policy, IID
-# Random policy, random batch
-# PointMass only: random transition, IID; random transition, random transition batch
 for env in ${ENVS}; do
   for discount in ${DISCOUNTS}; do
     for distance_kind in direct pearson; do

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -105,7 +105,7 @@ SAMPLE_FROM_DATASET_FACTORY = dict(
 
 @plot_canon_heatmap_ex.named_config
 def sample_from_serialized_policy():
-    """Configure to sample observations and actions from rollouts of a serialized policy."""
+    """Configure script to sample observations and actions from rollouts of a serialized policy."""
     locals().update(**SAMPLE_FROM_DATASET_FACTORY)
     sample_dist_factory_kwargs = {
         "dataset_factory": datasets.rollout_serialized_policy_generator,
@@ -119,7 +119,7 @@ def sample_from_serialized_policy():
 
 @plot_canon_heatmap_ex.named_config
 def dataset_from_serialized_policy():
-    """Configurable to sample batches from rollouts of a serialized policy.
+    """Configure script to sample batches from rollouts of a serialized policy.
 
     Only has effect when `computation_kind` equals `"sample"`.
     """

--- a/src/evaluating_rewards/canonical_sample.py
+++ b/src/evaluating_rewards/canonical_sample.py
@@ -215,6 +215,7 @@ def sample_canon_shaping(
     obs_dist: datasets.SampleDist,
     n_mean_samples: int,
     discount: float = 1.0,
+    p: int = 1,
 ) -> Mapping[K, np.ndarray]:
     r"""
     Canonicalize `batch` for `models` using a sample-based estimate of mean reward.
@@ -251,6 +252,7 @@ def sample_canon_shaping(
         obs_dist: The distribution to sample next observations from.
         n_mean_samples: The number of samples to take.
         discount: The discount parameter to use for potential shaping.
+        p: Controls power in the L^p norm used for normalization.
 
     Returns:
         A mapping from keys to NumPy arrays containing rewards from the model evaluated on batch
@@ -283,7 +285,7 @@ def sample_canon_shaping(
         # Note this is the only part of the computation that depends on discount, so it'd be
         # cheap to evaluate for many values of `discount` if needed.
         deshaped = raw + discount * mean_next_obs - mean_obs - discount * total
-        deshaped *= tabular.canonical_scale_normalizer(deshaped)
+        deshaped *= tabular.canonical_scale_normalizer(deshaped, p)
         deshaped_rew[k] = deshaped
 
     return deshaped_rew

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -152,7 +152,7 @@ def batch_callable_to_sample_dist(batch_callable: BatchCallable, obs: bool) -> S
     """Samples state/actions from batches returned by `batch_callable`.
 
     If `obs` is true, then samples observations from state and next state.
-    If `obs` is false, then samples actions from the action.
+    If `obs` is false, then samples actions.
     """
 
     def f(n: int) -> np.ndarray:

--- a/tests/test_canonical_sample.py
+++ b/tests/test_canonical_sample.py
@@ -60,11 +60,10 @@ def test_mesh_evaluate_models(
     graph: tf.Graph, session: tf.Session, space: gym.Space, n_models: int, n_mesh: int = 64,
 ):
     """Checks `canonical_sample.mesh_evaluate_models` agrees with `mesh_evaluate_models_slow`."""
-    dist = datasets.space_to_sample(space)
-
-    obs = dist(n_mesh)
-    actions = dist(n_mesh)
-    next_obs = dist(n_mesh)
+    with datasets.space_to_sample(space) as dist:
+        obs = dist(n_mesh)
+        actions = dist(n_mesh)
+        next_obs = dist(n_mesh)
 
     with graph.as_default():
         models = {}
@@ -113,10 +112,10 @@ def test_sample_canon_shaping(
                 }
             )
 
-    obs_dist = datasets.space_to_sample(venv.observation_space)
-    act_dist = datasets.space_to_sample(venv.action_space)
-    with datasets.iid_transition_generator(obs_dist, act_dist) as iid_generator:
-        batch = iid_generator(256)
+    with datasets.space_to_sample(venv.observation_space) as obs_dist:
+        with datasets.space_to_sample(venv.action_space) as act_dist:
+            with datasets.iid_transition_generator(obs_dist, act_dist) as iid_generator:
+                batch = iid_generator(256)
     canon_rew = canonical_sample.sample_canon_shaping(
         models, batch, act_dist, obs_dist, n_mean_samples=256, discount=discount,
     )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -49,6 +49,7 @@ EXPERIMENTS = {
 
 
 def add_canon_experiments():
+    """Add testcases for `evaluating_rewards.analysis.dissimilarity_heatmaps.plot_canon_heatmap`."""
     for computation_kind in ["sample", "mesh"]:
         for distance_kind in ["direct", "pearson"]:
             EXPERIMENTS[f"plot_canon_heatmap_{computation_kind}_{distance_kind}"] = (
@@ -57,6 +58,22 @@ def add_canon_experiments():
                 [],
                 {"computation_kind": computation_kind, "distance_kind": distance_kind},
             )
+    NAMED_CONFIGS = {
+        "random_policy": ["sample_from_serialized_policy"],
+        "random_policy_batch": ["sample_from_serialized_policy", "dataset_from_serialized_policy"],
+        "random_transitions_batch": [
+            "point_mass",
+            "sample_from_random_transitions",
+            "dataset_from_random_transitions",
+        ],
+    }
+    for name, named_configs in NAMED_CONFIGS.items():
+        EXPERIMENTS[f"plot_canon_heatmap_{name}"] = (
+            plot_canon_heatmap.plot_canon_heatmap_ex,
+            dict,
+            named_configs,
+            {},
+        )
 
 
 def add_gridworld_experiments():


### PR DESCRIPTION
The random sample and mesh-based methods of computing CANON require sampling from a distribution over observations and actions. Previously this was hardcoded in `plot_canon_heatmap` as randomly sampling from the Gym observation/action space. This is an extremely poor method especially in high-dimensional environments, where very few samples will be in any way physically realistic.

This PR makes this configurable in `plot_canon_heatmap`, in particular adding support for taking observations/actions from rollouts of a policy. To support this, the PR adds several methods to `datasets`, introducing a notion of a `SampleDistFactory` that is analogous to a `DatasetFactory`.