### PR TITLE
Update version of imitation replacing rewards.Batch with data.Transitions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ flake8-debugger
 flake8-isort
 hypothesis[numpy]
 isort
-pylint
+pylint>=2.4,<2.5
 pytype
 pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 benchmark-environments @ git+https://github.com/HumanCompatibleAI/benchmark-environments.git
-imitation @ git+https://github.com/HumanCompatibleAI/imitation.git@e99844
+imitation @ git+https://github.com/HumanCompatibleAI/imitation.git@b8b3de0
 stable-baselines @ git+https://github.com/hill-a/stable-baselines.git
 gym[mujoco]
 matplotlib

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -52,8 +52,8 @@ def default_config(env_name, log_root):
     # n_samples and n_mean_samples only applicable for sample approach
     n_samples = 4096  # number of samples in dataset
     n_mean_samples = 4096  # number of samples to estimate mean
-    dataset_factory = None  # defaults to datasets.iid_transition_generator
-    dataset_factory_kwargs = {"env_name": env_name}
+    visitations_factory = None  # defaults to datasets.iid_transition_generator
+    visitations_factory_kwargs = {"env_name": env_name}
     dataset_tag = "iid"
     # n_obs and n_act only applicable for mesh approach
     n_obs = 256
@@ -96,10 +96,10 @@ def logging_config(
 
 SAMPLE_FROM_DATASET_FACTORY = dict(
     obs_sample_dist_factory=functools.partial(
-        datasets.dataset_factory_to_sample_dist_factory, obs=True
+        datasets.transitions_factory_to_sample_dist_factory, obs=True
     ),
     act_sample_dist_factory=functools.partial(
-        datasets.dataset_factory_to_sample_dist_factory, obs=False
+        datasets.transitions_factory_to_sample_dist_factory, obs=False
     ),
 )
 
@@ -109,7 +109,7 @@ def sample_from_serialized_policy():
     """Configure script to sample observations and actions from rollouts of a serialized policy."""
     locals().update(**SAMPLE_FROM_DATASET_FACTORY)
     sample_dist_factory_kwargs = {
-        "dataset_factory": datasets.rollout_serialized_policy_generator,
+        "transitions_factory": datasets.rollout_serialized_policy_generator,
         "policy_type": "random",
         "policy_path": "dummy",
     }
@@ -124,8 +124,8 @@ def dataset_from_serialized_policy():
 
     Only has effect when `computation_kind` equals `"sample"`.
     """
-    dataset_factory = datasets.rollout_serialized_policy_generator
-    dataset_factory_kwargs = {
+    visitations_factory = datasets.rollout_serialized_policy_generator
+    visitations_factory_kwargs = {
         "policy_type": "random",
         "policy_path": "dummy",
     }
@@ -137,7 +137,7 @@ def dataset_from_serialized_policy():
 @plot_canon_heatmap_ex.named_config
 def sample_from_random_transitions():
     locals().update(**SAMPLE_FROM_DATASET_FACTORY)
-    sample_dist_factory_kwargs = {"dataset_factory": datasets.random_transition_generator}
+    sample_dist_factory_kwargs = {"transitions_factory": datasets.random_transition_generator}
     sample_dist_tag = "random_transitions"
     _ = locals()
     del _
@@ -145,7 +145,7 @@ def sample_from_random_transitions():
 
 @plot_canon_heatmap_ex.named_config
 def dataset_from_random_transitions():
-    dataset_factory = datasets.random_transition_generator
+    visitations_factory = datasets.random_transition_generator
     dataset_tag = "random_transitions"
     _ = locals()
     del _
@@ -291,8 +291,8 @@ def sample_canon(
     y_reward_cfgs: Iterable[config.RewardCfg],
     distance_kind: str,
     discount: float,
-    dataset_factory: Optional[datasets.TransitionsFactory],
-    dataset_factory_kwargs: Optional[Dict[str, Any]],
+    visitations_factory: Optional[datasets.TransitionsFactory],
+    visitations_factory_kwargs: Optional[Dict[str, Any]],
     n_samples: int,
     n_mean_samples: int,
     direct_p: int,
@@ -319,10 +319,10 @@ def sample_canon(
     """
     del g
     logger.info("Sampling dataset")
-    if dataset_factory is None:
-        dataset_factory = datasets.iid_transition_generator
-        dataset_factory_kwargs = dict(obs_dist=obs_dist, act_dist=act_dist)
-    with dataset_factory(**dataset_factory_kwargs) as batch_callable:
+    if visitations_factory is None:
+        visitations_factory = datasets.iid_transition_generator
+        visitations_factory_kwargs = dict(obs_dist=obs_dist, act_dist=act_dist)
+    with visitations_factory(**visitations_factory_kwargs) as batch_callable:
         batch = batch_callable(n_samples)
 
     with sess.as_default():

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -291,7 +291,7 @@ def sample_canon(
     y_reward_cfgs: Iterable[config.RewardCfg],
     distance_kind: str,
     discount: float,
-    dataset_factory: Optional[datasets.DatasetFactory],
+    dataset_factory: Optional[datasets.TransitionsFactory],
     dataset_factory_kwargs: Optional[Dict[str, Any]],
     n_samples: int,
     n_mean_samples: int,

--- a/src/evaluating_rewards/canonical_sample.py
+++ b/src/evaluating_rewards/canonical_sample.py
@@ -196,7 +196,7 @@ def sample_mean_rews(
             obs=obs_repeated,
             acts=act_tiled[: len(obs_repeated), :],
             next_obs=next_obs_tiled[: len(obs_repeated), :],
-            dones=np.zeros(obs.shape[0], dtype=np.bool),
+            dones=np.zeros(len(obs), dtype=np.bool),
         )
         rews = rewards.evaluate_models(models, batch)
         rews = {k: v.reshape(len(obs), -1) for k, v in rews.items()}

--- a/src/evaluating_rewards/canonical_sample.py
+++ b/src/evaluating_rewards/canonical_sample.py
@@ -212,7 +212,7 @@ def sample_mean_rews(
 
 def sample_canon_shaping(
     models: Mapping[K, rewards.RewardModel],
-    transitions: data.Transitions,
+    batch: data.Transitions,
     act_dist: datasets.SampleDist,
     obs_dist: datasets.SampleDist,
     n_mean_samples: int,
@@ -249,7 +249,7 @@ def sample_canon_shaping(
 
     Args:
         models: A mapping from keys to reward models.
-        transitions: A batch to evaluate the models with respect to.
+        batch: A batch to evaluate the models with respect to.
         act_dist: The distribution to sample actions from.
         obs_dist: The distribution to sample next observations from.
         n_mean_samples: The number of samples to take.
@@ -260,13 +260,13 @@ def sample_canon_shaping(
         A mapping from keys to NumPy arrays containing rewards from the model evaluated on batch
         and then canonicalized to be invariant to potential shaping and scale.
     """
-    raw_rew = rewards.evaluate_models(models, transitions)
+    raw_rew = rewards.evaluate_models(models, batch)
 
     # Sample-based estimate of mean reward
     act_samples = act_dist(n_mean_samples)
     next_obs_samples = obs_dist(n_mean_samples)
 
-    all_obs = np.concatenate((next_obs_samples, transitions.obs, transitions.next_obs), axis=0)
+    all_obs = np.concatenate((next_obs_samples, batch.obs, batch.next_obs), axis=0)
     unique_obs, unique_inv = np.unique(all_obs, return_inverse=True, axis=0)
     mean_rews = sample_mean_rews(models, unique_obs, act_samples, next_obs_samples)
     mean_rews = {k: v[unique_inv] for k, v in mean_rews.items()}

--- a/src/evaluating_rewards/canonical_sample.py
+++ b/src/evaluating_rewards/canonical_sample.py
@@ -196,7 +196,7 @@ def sample_mean_rews(
             obs=obs_repeated,
             acts=act_tiled[: len(obs_repeated), :],
             next_obs=next_obs_tiled[: len(obs_repeated), :],
-            dones=np.zeros(len(obs), dtype=np.bool),
+            dones=np.zeros(len(obs_repeated), dtype=np.bool),
         )
         rews = rewards.evaluate_models(models, batch)
         rews = {k: v.reshape(len(obs), -1) for k, v in rews.items()}

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -24,19 +24,17 @@ from typing import Callable, ContextManager, Iterator, Union
 
 import gym
 from imitation.policies import serialize
-from imitation.util import rollout, util
+from imitation.util import data, rollout, util
 import numpy as np
 from stable_baselines.common import base_class, policies, vec_env
 
-from evaluating_rewards import rewards
-
 SampleDist = Callable[[int], np.ndarray]
-BatchCallable = Callable[[int], rewards.Batch]
+TransitionsCallable = Callable[[int], data.Transitions]
 # Expect DatasetFactory to accept a str specifying env_name as first argument,
 # int specifying seed as second argument and factory-specific keyword arguments
 # after this. There is no way to specify this in Python type annotations yet :(
 # See https://github.com/python/mypy/issues/5876
-DatasetFactory = Callable[..., ContextManager[BatchCallable]]
+TransitionsFactory = Callable[..., ContextManager[TransitionsCallable]]
 SampleDistFactory = Callable[..., ContextManager[SampleDist]]
 
 
@@ -62,16 +60,12 @@ def env_name_to_sample(env_name: str, obs: bool) -> Iterator[SampleDist]:
 @contextlib.contextmanager
 def rollout_policy_generator(
     venv: vec_env.VecEnv, policy: Union[base_class.BaseRLModel, policies.BasePolicy]
-) -> Iterator[BatchCallable]:
+) -> Iterator[TransitionsCallable]:
     """Generator returning rollouts from a policy in a given environment."""
 
-    def f(total_timesteps: int) -> rewards.Batch:
+    def f(total_timesteps: int) -> data.Transitions:
         # TODO(adam): inefficient -- discards partial trajectories and resets environment
-        transitions = rollout.generate_transitions(policy, venv, n_timesteps=total_timesteps)
-        # TODO(): can we switch to rollout.Transition?
-        return rewards.Batch(
-            obs=transitions.obs, actions=transitions.acts, next_obs=transitions.next_obs
-        )
+        return rollout.generate_transitions(policy, venv, n_timesteps=total_timesteps)
 
     yield f
 
@@ -79,7 +73,7 @@ def rollout_policy_generator(
 @contextlib.contextmanager
 def rollout_serialized_policy_generator(
     env_name: str, policy_type: str, policy_path: str, num_vec: int = 8, seed: int = 0
-) -> Iterator[BatchCallable]:
+) -> Iterator[TransitionsCallable]:
     venv = util.make_vec_env(env_name, n_envs=num_vec, seed=seed)
     with serialize.load_policy(policy_type, policy_path, venv) as policy:
         with rollout_policy_generator(venv, policy) as generator:
@@ -87,7 +81,7 @@ def rollout_serialized_policy_generator(
 
 
 @contextlib.contextmanager
-def random_transition_generator(env_name: str, seed: int = 0) -> Iterator[BatchCallable]:
+def random_transition_generator(env_name: str, seed: int = 0) -> Iterator[TransitionsCallable]:
     """Randomly samples state and action and computes next state from dynamics.
 
     This is one of the weakest possible priors, with broad support. It is similar
@@ -108,7 +102,7 @@ def random_transition_generator(env_name: str, seed: int = 0) -> Iterator[BatchC
     env = gym.make(env_name)
     env.seed(seed)
 
-    def f(total_timesteps: int) -> rewards.Batch:
+    def f(total_timesteps: int) -> data.Transitions:
         """Helper function."""
         obses = []
         acts = []
@@ -123,32 +117,38 @@ def random_transition_generator(env_name: str, seed: int = 0) -> Iterator[BatchC
             obses.append(obs)
             acts.append(act)
             next_obses.append(next_obs)
-        return rewards.Batch(
-            obs=np.array(obses), actions=np.array(acts), next_obs=np.array(next_obses)
+        dones = np.zeros(total_timesteps, dtype=np.bool)
+        return data.Transitions(
+            obs=np.array(obses), acts=np.array(acts), next_obs=np.array(next_obses), dones=dones,
         )
 
     yield f
 
 
 @contextlib.contextmanager
-def iid_transition_generator(obs_dist: SampleDist, act_dist: SampleDist) -> Iterator[BatchCallable]:
+def iid_transition_generator(
+    obs_dist: SampleDist, act_dist: SampleDist
+) -> Iterator[TransitionsCallable]:
     """Samples state and next state i.i.d. from `obs_dist` and actions i.i.d. from `act_dist`.
 
     This is an extremely weak prior. It's most useful in conjunction with methods in
     `canonical_sample` which assume i.i.d. transitions internally."""
 
-    def f(total_timesteps: int) -> rewards.Batch:
+    def f(total_timesteps: int) -> data.Transitions:
         obses = obs_dist(total_timesteps)
         acts = act_dist(total_timesteps)
         next_obses = obs_dist(total_timesteps)
-        return rewards.Batch(
-            obs=np.array(obses), actions=np.array(acts), next_obs=np.array(next_obses)
+        dones = np.zeros(total_timesteps, dtype=np.bool)
+        return data.Transitions(
+            obs=np.array(obses), acts=np.array(acts), next_obs=np.array(next_obses), dones=dones,
         )
 
     yield f
 
 
-def batch_callable_to_sample_dist(batch_callable: BatchCallable, obs: bool) -> SampleDist:
+def transitions_callable_to_sample_dist(
+    transitions_callable: TransitionsCallable, obs: bool
+) -> SampleDist:
     """Samples state/actions from batches returned by `batch_callable`.
 
     If `obs` is true, then samples observations from state and next state.
@@ -157,11 +157,11 @@ def batch_callable_to_sample_dist(batch_callable: BatchCallable, obs: bool) -> S
 
     def f(n: int) -> np.ndarray:
         num_timesteps = ((n - 1) // 2 + 1) if obs else n
-        batch = batch_callable(num_timesteps)
+        transitions = transitions_callable(num_timesteps)
         if obs:
-            res = np.concatenate((batch.obs, batch.next_obs))
+            res = np.concatenate((transitions.obs, transitions.next_obs))
         else:
-            res = batch.actions
+            res = transitions.acts
         return res[:n]
 
     return f
@@ -169,7 +169,7 @@ def batch_callable_to_sample_dist(batch_callable: BatchCallable, obs: bool) -> S
 
 @contextlib.contextmanager
 def dataset_factory_to_sample_dist_factory(
-    dataset_factory: DatasetFactory, obs: bool, **kwargs
+    dataset_factory: TransitionsFactory, obs: bool, **kwargs
 ) -> Iterator[SampleDist]:
-    with dataset_factory(**kwargs) as batch_callable:
-        yield batch_callable_to_sample_dist(batch_callable, obs)
+    with dataset_factory(**kwargs) as transitions_callable:
+        yield transitions_callable_to_sample_dist(transitions_callable, obs)

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -168,8 +168,8 @@ def transitions_callable_to_sample_dist(
 
 
 @contextlib.contextmanager
-def dataset_factory_to_sample_dist_factory(
-    dataset_factory: TransitionsFactory, obs: bool, **kwargs
+def transitions_factory_to_sample_dist_factory(
+    transitions_factory: TransitionsFactory, obs: bool, **kwargs
 ) -> Iterator[SampleDist]:
-    with dataset_factory(**kwargs) as transitions_callable:
+    with transitions_factory(**kwargs) as transitions_callable:
         yield transitions_callable_to_sample_dist(transitions_callable, obs)

--- a/src/evaluating_rewards/experiments/comparisons.py
+++ b/src/evaluating_rewards/experiments/comparisons.py
@@ -49,7 +49,7 @@ def norm_diff(predicted: np.ndarray, actual: np.ndarray, norm: int):
 def constant_baseline(
     match: comparisons.RegressModel,
     target: rewards.RewardModel,
-    dataset: datasets.BatchCallable,
+    dataset: datasets.TransitionsCallable,
     test_size: int = 4096,
 ) -> Dict[str, Any]:
     """Computes the error in predictions of the model matched and some baselines.

--- a/src/evaluating_rewards/experiments/monte_carlo.py
+++ b/src/evaluating_rewards/experiments/monte_carlo.py
@@ -17,7 +17,7 @@
 import warnings
 
 from imitation.policies import serialize as policy_serialize
-from imitation.util import registry
+from imitation.util import data, registry
 import numpy as np
 from stable_baselines.common import policies, vec_env
 import tensorflow as tf
@@ -100,7 +100,8 @@ class MonteCarloGreedyPolicy(policies.BasePolicy):
             )
             next_obs = dup_obs
 
-        batch = rewards.Batch(obs=dup_obs, actions=dup_actions, next_obs=next_obs)
+        dones = np.zeros(batch_size * self.n_samples, dtype=np.bool)
+        batch = data.Transitions(obs=dup_obs, acts=dup_actions, next_obs=next_obs, dones=dones)
         feed_dict = rewards.make_feed_dict([self.reward_model], batch)
         # TODO(): add a function to RewardModel to compute this?
         reward = self.sess.run(self.reward_model.reward, feed_dict=feed_dict)

--- a/src/evaluating_rewards/experiments/point_mass_analysis.py
+++ b/src/evaluating_rewards/experiments/point_mass_analysis.py
@@ -21,6 +21,7 @@ import itertools
 from typing import List, Tuple
 from unittest import mock
 
+from imitation.util import data
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
@@ -102,7 +103,7 @@ def mesh_input(
     vel_lim: float = 1.0,
     act_lim: float = 1.0,
     density: int = 21,
-) -> Tuple[List[List[int]], rewards.Batch]:
+) -> Tuple[List[List[int]], data.Transitions]:
     """Computes a grid dataset of observation, actions and next observations.
 
     Specifically, it computes a grid of position, velocity and actions
@@ -140,7 +141,8 @@ def mesh_input(
     next_states = env.transition(states, actions)
     next_obs = env.obs_from_state(next_states)
 
-    dataset = rewards.Batch(obs=obs, actions=actions, next_obs=next_obs)
+    dones = np.zeros(obs.shape[0], dtype=np.bool)
+    dataset = data.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones)
     return idxs, dataset
 
 
@@ -168,7 +170,7 @@ def evaluate_reward_model(
 
 
 def plot_state_density(
-    dataset_generator: datasets.BatchCallable, nsamples: int = 2 ** 12, **kwargs
+    dataset_generator: datasets.TransitionsCallable, nsamples: int = 2 ** 12, **kwargs
 ):
     """Plots the density of a state distribution.
 

--- a/src/evaluating_rewards/experiments/point_mass_analysis.py
+++ b/src/evaluating_rewards/experiments/point_mass_analysis.py
@@ -141,7 +141,7 @@ def mesh_input(
     next_states = env.transition(states, actions)
     next_obs = env.obs_from_state(next_states)
 
-    dones = np.zeros(obs.shape[0], dtype=np.bool)
+    dones = np.zeros(len(obs), dtype=np.bool)
     dataset = data.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones)
     return idxs, dataset
 

--- a/src/evaluating_rewards/experiments/synthetic.py
+++ b/src/evaluating_rewards/experiments/synthetic.py
@@ -22,6 +22,7 @@ import logging
 from typing import Any, Callable, Iterable, List, Mapping, Optional, Tuple, Type
 
 import gym
+from imitation.util import data
 import numpy as np
 import pandas as pd
 import scipy as sp
@@ -134,7 +135,7 @@ def _compare_synthetic_eval(
     metrics: Mapping[str, List[Mapping[Tuple[float, float], Any]]],
     originals,
     matchings,
-    test_set: rewards.Batch,
+    test_set: data.Transitions,
     initial_constants: Mapping[Tuple[float, float], float],
     initial_scales: Mapping[Tuple[float, float], float],
     gt_constant: float,
@@ -207,7 +208,7 @@ def _compare_synthetic_eval(
 def compare_synthetic(
     observation_space: gym.Space,
     action_space: gym.Space,
-    dataset_generator: datasets.BatchCallable,
+    dataset_generator: datasets.TransitionsCallable,
     reward_noise: Optional[np.ndarray] = None,
     potential_noise: Optional[np.ndarray] = None,
     reward_hids: Optional[Iterable[int]] = None,
@@ -368,7 +369,7 @@ def compare_synthetic(
 def summary_stats(
     observation_space: gym.Space,
     action_space: gym.Space,
-    dataset: rewards.Batch,
+    dataset: data.Transitions,
     reward_hids: Optional[Iterable[int]] = None,
     potential_hids: Optional[Iterable[int]] = None,
 ):

--- a/src/evaluating_rewards/preferences.py
+++ b/src/evaluating_rewards/preferences.py
@@ -307,7 +307,7 @@ class PreferenceComparisonTrainer:
         obs = _concatenate(preferences, "obs", slice(0, -1))
         acts = _concatenate(preferences, "acts", slice(None))
         next_obs = _concatenate(preferences, "obs", slice(1, None))
-        dones = np.zeros(obs.shape[0], dtype=np.bool)
+        dones = np.zeros(len(obs), dtype=np.bool)
         batch = data.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones)
         feed_dict = rewards.make_feed_dict([self.model], batch)
         labels = np.array([p.label for p in preferences])

--- a/src/evaluating_rewards/preferences.py
+++ b/src/evaluating_rewards/preferences.py
@@ -75,10 +75,7 @@ def _slice_trajectory(trajectory: data.Trajectory, start: int, end: int) -> data
     """Slice trajectory from timestep start to timestep end."""
     infos = trajectory.infos[start:end] if trajectory.infos is not None else None
     return data.Trajectory(
-        obs=trajectory.obs[start : end + 1],
-        acts=trajectory.acts[start:end],
-        rews=trajectory.rews[start:end],
-        infos=infos,
+        obs=trajectory.obs[start : end + 1], acts=trajectory.acts[start:end], infos=infos,
     )
 
 
@@ -307,11 +304,11 @@ class PreferenceComparisonTrainer:
         Returns:
             A feed dict.
         """
-        batch = rewards.Batch(
-            obs=_concatenate(preferences, "obs", slice(0, -1)),
-            actions=_concatenate(preferences, "acts", slice(None)),
-            next_obs=_concatenate(preferences, "obs", slice(1, None)),
-        )
+        obs = _concatenate(preferences, "obs", slice(0, -1))
+        acts = _concatenate(preferences, "acts", slice(None))
+        next_obs = _concatenate(preferences, "obs", slice(1, None))
+        dones = np.zeros(obs.shape[0], dtype=np.bool)
+        batch = data.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones)
         feed_dict = rewards.make_feed_dict([self.model], batch)
         labels = np.array([p.label for p in preferences])
         feed_dict[self._preference_labels] = labels

--- a/src/evaluating_rewards/preferences.py
+++ b/src/evaluating_rewards/preferences.py
@@ -26,7 +26,7 @@ import logging
 import math
 from typing import Any, Dict, Iterable, List, NamedTuple, Sequence, Type
 
-from imitation.util import rollout
+from imitation.util import data, rollout
 import numpy as np
 import pandas as pd
 from stable_baselines.common import policies, vec_env
@@ -44,8 +44,8 @@ class TrajectoryPreference(NamedTuple):
         - label: 0 if traja is best, 1 if trajb is best.
     """
 
-    traja: rollout.Trajectory
-    trajb: rollout.Trajectory
+    traja: data.Trajectory
+    trajb: data.Trajectory
     label: int
 
 
@@ -71,10 +71,10 @@ def _concatenate(preferences: List[TrajectoryPreference], attr: str, idx: slice)
     return stacked.reshape((-1,) + stacked.shape[3:])
 
 
-def _slice_trajectory(trajectory: rollout.Trajectory, start: int, end: int) -> rollout.Trajectory:
+def _slice_trajectory(trajectory: data.Trajectory, start: int, end: int) -> data.Trajectory:
     """Slice trajectory from timestep start to timestep end."""
     infos = trajectory.infos[start:end] if trajectory.infos is not None else None
-    return rollout.Trajectory(
+    return data.Trajectory(
         obs=trajectory.obs[start : end + 1],
         acts=trajectory.acts[start:end],
         rews=trajectory.rews[start:end],
@@ -84,7 +84,7 @@ def _slice_trajectory(trajectory: rollout.Trajectory, start: int, end: int) -> r
 
 def generate_trajectories(
     venv: vec_env.VecEnv, policy: policies.BasePolicy, trajectory_length: int, num_trajectories: int
-) -> Sequence[rollout.Trajectory]:
+) -> Sequence[data.Trajectory]:
     """Rollouts policy in venv collecting num_trajectories segments.
 
     Complete episodes are collected. An episode of length N is split into
@@ -103,7 +103,7 @@ def generate_trajectories(
         trajectory_length.
     """
 
-    def sample_until(episodes: Sequence[rollout.Trajectory]):
+    def sample_until(episodes: Sequence[data.Trajectory]):
         """Computes whether a full batch of data has been collected."""
         episode_lengths = np.array([len(t.acts) for t in episodes])
         num_trajs = episode_lengths // trajectory_length

--- a/src/evaluating_rewards/rewards.py
+++ b/src/evaluating_rewards/rewards.py
@@ -22,7 +22,7 @@ from typing import Dict, Iterable, Mapping, NamedTuple, Optional, Sequence, Tupl
 
 import gym
 from imitation.rewards import reward_net
-from imitation.util import rollout, serialize
+from imitation.util import data, rollout, serialize
 import numpy as np
 import scipy.optimize
 from stable_baselines.common import input as env_in  # avoid name clash
@@ -746,7 +746,7 @@ def evaluate_models(models: Mapping[K, RewardModel], batch: Batch) -> Mapping[K,
 
 
 def compute_returns(
-    models: Mapping[K, RewardModel], trajectories: Sequence[rollout.Trajectory]
+    models: Mapping[K, RewardModel], trajectories: Sequence[data.Trajectory]
 ) -> Mapping[K, np.ndarray]:
     """Computes the (undiscounted) returns of each trajectory under each model.
 

--- a/src/evaluating_rewards/scripts/model_comparison.py
+++ b/src/evaluating_rewards/scripts/model_comparison.py
@@ -156,7 +156,7 @@ def model_comparison(
     # Dataset
     env_name: str,
     discount: float,
-    dataset_factory: datasets.DatasetFactory,
+    dataset_factory: datasets.TransitionsFactory,
     dataset_factory_kwargs: Dict[str, Any],
     # Source specification
     source_reward_type: str,

--- a/src/evaluating_rewards/scripts/train_regress.py
+++ b/src/evaluating_rewards/scripts/train_regress.py
@@ -77,7 +77,7 @@ def train_regress(
     # Dataset
     env_name: str,
     discount: float,
-    dataset_factory: datasets.DatasetFactory,
+    dataset_factory: datasets.TransitionsFactory,
     dataset_factory_kwargs: Dict[str, Any],
     # Target specification
     target_reward_type: str,

--- a/src/evaluating_rewards/serialize.py
+++ b/src/evaluating_rewards/serialize.py
@@ -65,7 +65,7 @@ class RewardRegistry(registry.Registry[RewardLoaderFn]):
                     """Helper method computing reward for registered model."""
                     del steps
                     # TODO(adam): RewardFn should probably include dones?
-                    dones = np.zeros(obs.shape[0], dtype=np.bool)
+                    dones = np.zeros(len(obs), dtype=np.bool)
                     transitions = data.Transitions(
                         obs=obs, acts=actions, next_obs=next_obs, dones=dones
                     )

--- a/src/evaluating_rewards/serialize.py
+++ b/src/evaluating_rewards/serialize.py
@@ -20,7 +20,7 @@ import os
 from typing import Callable, Iterator, Optional
 import uuid
 
-from imitation.rewards import reward_net, serialize
+from imitation.rewards import common, reward_net, serialize
 from imitation.util import registry
 from imitation.util import serialize as util_serialize
 from imitation.util import util
@@ -53,7 +53,7 @@ class RewardRegistry(registry.Registry[RewardLoaderFn]):
         super().register(key, value=value, indirect=indirect)
 
         @contextlib.contextmanager
-        def reward_fn_loader(path: str, venv: vec_env.VecEnv) -> Iterator[serialize.RewardFn]:
+        def reward_fn_loader(path: str, venv: vec_env.VecEnv) -> Iterator[common.RewardFn]:
             """Load a TensorFlow reward model, then convert it into a Callable."""
             reward_model_loader = self.get(key)
             with util.make_session() as (_, sess):

--- a/src/evaluating_rewards/serialize.py
+++ b/src/evaluating_rewards/serialize.py
@@ -21,7 +21,7 @@ from typing import Callable, Iterator, Optional
 import uuid
 
 from imitation.rewards import common, reward_net, serialize
-from imitation.util import registry
+from imitation.util import data, registry
 from imitation.util import serialize as util_serialize
 from imitation.util import util
 import numpy as np
@@ -64,8 +64,12 @@ class RewardRegistry(registry.Registry[RewardLoaderFn]):
                 ) -> np.ndarray:
                     """Helper method computing reward for registered model."""
                     del steps
-                    batch = rewards.Batch(obs=obs, actions=actions, next_obs=next_obs)
-                    fd = rewards.make_feed_dict([reward_model], batch)
+                    # TODO(adam): RewardFn should probably include dones?
+                    dones = np.zeros(obs.shape[0], dtype=np.bool)
+                    transitions = data.Transitions(
+                        obs=obs, acts=actions, next_obs=next_obs, dones=dones
+                    )
+                    fd = rewards.make_feed_dict([reward_model], transitions)
                     return sess.run(reward_model.reward, feed_dict=fd)
 
                 yield reward_fn

--- a/tests/test_canonical_sample.py
+++ b/tests/test_canonical_sample.py
@@ -42,7 +42,9 @@ def mesh_evaluate_models_slow(
     It might also be useful in the future for other optimisations (e.g. a JIT like Numba).
     """
     transitions = list(itertools.product(obs, actions, next_obs))
-    transitions = [np.array([m[i] for m in transitions]) for i in range(3)]
+    transitions = [
+        np.array([m[i] for m in transitions]) for i in range(3)  # pylint:disable=not-an-iterable
+    ]
     dones = np.zeros(transitions[0].shape, dtype=np.bool)
     transitions = data.Transitions(*transitions, dones)
     rews = rewards.evaluate_models(models, transitions)

--- a/tests/test_canonical_sample.py
+++ b/tests/test_canonical_sample.py
@@ -42,11 +42,13 @@ def mesh_evaluate_models_slow(
     It might also be useful in the future for other optimisations (e.g. a JIT like Numba).
     """
     transitions = list(itertools.product(obs, actions, next_obs))
-    transitions = [
+    tiled_obs, tiled_acts, tiled_next_obs = (
         np.array([m[i] for m in transitions]) for i in range(3)  # pylint:disable=not-an-iterable
-    ]
-    dones = np.zeros(transitions[0].shape, dtype=np.bool)
-    transitions = data.Transitions(*transitions, dones)
+    )
+    dones = np.zeros(len(tiled_obs), dtype=np.bool)
+    transitions = data.Transitions(
+        obs=tiled_obs, acts=tiled_acts, next_obs=tiled_next_obs, dones=dones
+    )
     rews = rewards.evaluate_models(models, transitions)
     rews = {k: v.reshape(len(obs), len(actions), len(next_obs)) for k, v in rews.items()}
     return rews

--- a/tests/test_canonical_sample.py
+++ b/tests/test_canonical_sample.py
@@ -18,6 +18,7 @@ import itertools
 from typing import Mapping
 
 import gym
+from imitation.util import data
 import numpy as np
 import pytest
 from stable_baselines.common import vec_env
@@ -40,10 +41,11 @@ def mesh_evaluate_models_slow(
     also much slower (around 20x). We use it for testing to verify they produce the same results.
     It might also be useful in the future for other optimisations (e.g. a JIT like Numba).
     """
-    batch = list(itertools.product(obs, actions, next_obs))
-    batch = [np.array([m[i] for m in batch]) for i in range(3)]
-    batch = rewards.Batch(*batch)
-    rews = rewards.evaluate_models(models, batch)
+    transitions = list(itertools.product(obs, actions, next_obs))
+    transitions = [np.array([m[i] for m in transitions]) for i in range(3)]
+    dones = np.zeros(transitions[0].shape, dtype=np.bool)
+    transitions = data.Transitions(*transitions, dones)
+    rews = rewards.evaluate_models(models, transitions)
     rews = {k: v.reshape(len(obs), len(actions), len(next_obs)) for k, v in rews.items()}
     return rews
 

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -198,15 +198,12 @@ def test_ground_truth_similar_to_gym(graph, session, venv, reward_id):
     # Generate rollouts, recording Gym reward
     policy = base.RandomPolicy(venv.observation_space, venv.action_space)
     transitions = rollout.generate_transitions(policy, venv, n_timesteps=1024)
-    batch = rewards.Batch(
-        obs=transitions.obs, actions=transitions.acts, next_obs=transitions.next_obs
-    )
     gym_reward = transitions.rews
 
     # Make predictions using reward model
     with graph.as_default(), session.as_default():
         reward_model = serialize.load_reward(reward_id, "dummy", venv, 1.0)
-        pred_reward = rewards.evaluate_models({"m": reward_model}, batch)["m"]
+        pred_reward = rewards.evaluate_models({"m": reward_model}, transitions)["m"]
 
     # Are the predictions close to true Gym reward?
     np.testing.assert_allclose(gym_reward, pred_reward, rtol=0, atol=5e-5)

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -21,13 +21,13 @@ evaluating_rewards.util.
 import logging
 
 import gym
-from imitation import util
+from imitation.util import data, util
 import numpy as np
 import pandas as pd
 import pytest
 import tensorflow as tf
 
-from evaluating_rewards import datasets, rewards
+from evaluating_rewards import datasets
 from evaluating_rewards.envs import point_mass
 from evaluating_rewards.experiments import synthetic
 from tests import common
@@ -42,7 +42,8 @@ def dummy_env_and_dataset(dims: int = 5):
         obs = np.array([obs_space.sample() for _ in range(total_timesteps)])
         actions = np.array([act_space.sample() for _ in range(total_timesteps)])
         next_obs = (obs + actions).clip(0.0, 1.0)
-        return rewards.Batch(obs=obs, actions=actions, next_obs=next_obs)
+        dones = np.zeros(total_timesteps, dtype=np.bool)
+        return data.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones)
 
     return {
         "observation_space": obs_space,


### PR DESCRIPTION
Upgrade to latest version of [imitation](http://github.com/humancompatibleai/imitation). Most API changes are minor. The main one is there is now a [Transitions](https://github.com/HumanCompatibleAI/imitation/pull/180) class which can replace our `rewards.Batch`, so I've gone through and removed that.