### PR TITLE
Convert environments to fixed horizon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-benchmark-environments @ git+https://github.com/HumanCompatibleAI/benchmark-environments.git
+benchmark-environments @ git+https://github.com/HumanCompatibleAI/benchmark-environments.git@d5edf5c
 imitation @ git+https://github.com/HumanCompatibleAI/imitation.git@b8b3de0
 stable-baselines @ git+https://github.com/hill-a/stable-baselines.git
 gym[mujoco]

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/config.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/config.py
@@ -156,7 +156,7 @@ def make_config(
     @experiment.named_config
     def half_cheetah():
         """Heatmaps for HalfCheetah-v3."""
-        env_name = "evaluating_rewards/HalfCheetah-v3"
+        env_name = "benchmark_environments/HalfCheetah-v0"
         kinds = [
             f"evaluating_rewards/HalfCheetahGroundTruth{suffix}-v0"
             for suffix in MUJOCO_STANDARD_ORDER
@@ -176,7 +176,7 @@ def make_config(
     @experiment.named_config
     def hopper():
         """Heatmaps for Hopper-v3."""
-        env_name = "evaluating_rewards/Hopper-v3"
+        env_name = "benchmark_environments/Hopper-v0"
         activities = ["GroundTruth", "Backflip"]
         kinds = [
             f"evaluating_rewards/Hopper{prefix}{suffix}-v0"

--- a/src/evaluating_rewards/envs/__init__.py
+++ b/src/evaluating_rewards/envs/__init__.py
@@ -14,6 +14,7 @@
 
 """Module for Gym environments. __init__ registers environments."""
 
+import benchmark_environments  # noqa: F401  pylint:disable=unused-import
 import gym
 import imitation.envs.examples  # noqa: F401  pylint:disable=unused-import
 
@@ -37,40 +38,3 @@ register_point_mass("Line", ndim=1, threshold=0.05)
 register_point_mass("LineVariableHorizon", ndim=1, threshold=-1)
 register_point_mass("LineStateOnly", ndim=1, ctrl_coef=0.0)
 register_point_mass("Grid", ndim=2)
-
-
-def register_similar(existing_name: str, new_name: str, **kwargs_delta):
-    """Registers a gym environment at new_id modifying existing_id by kwargs.
-
-    Args:
-        existing_name: The name of an environment registered in Gym.
-        new_name: The new name to register with Gym.
-        **kwargs_delta: Arguments to override the specification from existing_id.
-    """
-    existing_spec = gym.spec(existing_name)
-    fields = ["entry_point", "reward_threshold", "nondeterministic", "max_episode_steps"]
-    kwargs = {k: getattr(existing_spec, k) for k in fields}
-    kwargs["kwargs"] = existing_spec._kwargs  # pylint:disable=protected-access
-    kwargs.update(**kwargs_delta)
-    gym.register(id=new_name, **kwargs)
-
-
-GYM_MUJOCO_V3_ENVS = [
-    "Ant-v3",
-    "HalfCheetah-v3",
-    "Hopper-v3",
-    "Humanoid-v3",
-    "Swimmer-v3",
-    "Walker2d-v3",
-]
-
-
-def register_mujoco():
-    kwargs = dict(exclude_current_positions_from_observation=False)
-    for env_name in GYM_MUJOCO_V3_ENVS:
-        register_similar(
-            existing_name=env_name, new_name=f"evaluating_rewards/{env_name}", kwargs=kwargs
-        )
-
-
-register_mujoco()

--- a/src/evaluating_rewards/envs/mujoco.py
+++ b/src/evaluating_rewards/envs/mujoco.py
@@ -176,16 +176,16 @@ class HopperGroundTruthReward(MujocoHardcodedReward):
         dt = 0.008  # model timestep 0.002, frameskip 4
         reward_vel = (self._proc_next_obs[:, 0] - self._proc_obs[:, 0]) / dt
         reward_ctrl = tf.reduce_sum(tf.square(self._proc_act), axis=-1)
-        reward = self.alive_bonus + forward_sign * reward_vel - self.ctrl_coef * reward_ctrl
+        reward = forward_sign * reward_vel - self.ctrl_coef * reward_ctrl
 
-        height = self._proc_obs[:, 1]
-        angle = self._proc_obs[:, 2]
-        finite = tf.math.reduce_all(tf.math.is_finite(self._proc_obs), axis=-1)
-        small_enough = tf.math.reduce_all(tf.abs(self._proc_obs[:, 2:]) < 100, axis=-1)
+        height = self._proc_next_obs[:, 1]
+        angle = self._proc_next_obs[:, 2]
+        finite = tf.math.reduce_all(tf.math.is_finite(self._proc_next_obs), axis=-1)
+        small_enough = tf.math.reduce_all(tf.abs(self._proc_next_obs[:, 2:]) < 100, axis=-1)
         alive_conditions = [finite, small_enough, height > 0.7, tf.abs(angle) < 0.2]
         alive = tf.math.reduce_all(alive_conditions, axis=0)
         # zero out rewards when starting observation was terminal
-        reward = reward * tf.cast(alive, tf.float32)
+        reward += self.alive_bonus * tf.cast(alive, tf.float32)
 
         return reward
 

--- a/src/evaluating_rewards/experiments/env_rewards.py
+++ b/src/evaluating_rewards/experiments/env_rewards.py
@@ -20,8 +20,8 @@ from typing import Iterable, Set
 from evaluating_rewards import serialize
 
 REWARDS_BY_ENV = {
-    "evaluating_rewards/HalfCheetah-v3": ["evaluating_rewards/HalfCheetahGroundTruth.*-v0"],
-    "evaluating_rewards/Hopper-v3": ["evaluating_rewards/Hopper.*-v0"],
+    "benchmark_environments/HalfCheetah-v0": ["evaluating_rewards/HalfCheetahGroundTruth.*-v0"],
+    "benchmark_environments/Hopper-v0": ["evaluating_rewards/Hopper.*-v0"],
     "evaluating_rewards/PointMassLine-v0": ["evaluating_rewards/PointMass.*-v0"],
     "imitation/PointMazeLeftVel-v0": ["evaluating_rewards/PointMaze.*-v0"],
     "imitation/PointMazeRightVel-v0": ["evaluating_rewards/PointMaze.*-v0"],

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -33,17 +33,17 @@ ENVS = ["FrozenLake-v0", "CartPole-v1", "Pendulum-v0"]
 
 STANDALONE_REWARD_MODELS = {
     "halfcheetah_ground_truth": {
-        "env_name": "evaluating_rewards/HalfCheetah-v3",
+        "env_name": "benchmark_environments/HalfCheetah-v0",
         "model_class": mujoco.HalfCheetahGroundTruthReward,
         "kwargs": {},
     },
     "hopper_ground_truth": {
-        "env_name": "evaluating_rewards/Hopper-v3",
+        "env_name": "benchmark_environments/Hopper-v0",
         "model_class": mujoco.HopperGroundTruthReward,
         "kwargs": {},
     },
     "hopper_backflip": {
-        "env_name": "evaluating_rewards/Hopper-v3",
+        "env_name": "benchmark_environments/Hopper-v0",
         "model_class": mujoco.HopperBackflipReward,
         "kwargs": {},
     },
@@ -84,12 +84,16 @@ REWARD_WRAPPERS = [
 
 GROUND_TRUTH = {
     "half_cheetah": (
-        "evaluating_rewards/HalfCheetah-v3",
+        "benchmark_environments/HalfCheetah-v0",
         "evaluating_rewards/HalfCheetahGroundTruthForwardWithCtrl-v0",
     ),
     "hopper": (
-        "evaluating_rewards/Hopper-v3",
+        "benchmark_environments/Hopper-v0",
         "evaluating_rewards/HopperGroundTruthForwardWithCtrl-v0",
+    ),
+    "point_mass": (
+        "evaluating_rewards/PointMassLine-v0",
+        "evaluating_rewards/PointMassGroundTruth-v0",
     ),
     "point_maze": (
         "imitation/PointMazeLeftVel-v0",


### PR DESCRIPTION
  - For MuJoCo tasks, swap to using implementations from `benchmark_environments`. Not much "implementation" of ours to remove: just removing some registration statements, since we were just doing a thin wrapper around Gym.
  - For PointMass,
  - Fix bugs I found in the PointMass and Hopper ground-truth reward models. This is unlikely to meaningfully change results: regression and preferences were trained directly on the reward model anyway, and the differences were not the kind to change optimal policy so should make little difference to IRL.