### PR TITLE
Compute and report confidence intervals in heatmaps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pandas
 pymdptoolbox
 seaborn
 setuptools
+scikit-learn
 scipy
 tensorflow>=1.15,<1.16
 xarray

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -283,12 +283,15 @@ def make_config(
         Used in plot_{canon,epic}_heatmap; currently ignored by plot_return_heatmap since
         it does not use multiple seeds and instead bootstraps over samples.
         """
-        aggregate_fns = {
-            "bootstrap": functools.partial(bootstrap_ci, n_bootstrap=n_bootstrap, alpha=alpha),
-            "studentt": functools.partial(studentt_ci, alpha=alpha),
-            "sample": sample_mean_sd,
-        }
-        aggregate_fns = {k: aggregate_fns[k] for k in aggregate_kinds}  # noqa: F401
+        aggregate_fns = {}
+        if "bootstrap" in aggregate_kinds:
+            aggregate_fns["bootstrap"] = functools.partial(
+                bootstrap_ci, n_bootstrap=n_bootstrap, alpha=alpha
+            )
+        if "studentt" in aggregate_kinds:
+            aggregate_fns["studentt"] = functools.partial(studentt_ci, alpha=alpha)
+        if "sample" in aggregate_kinds:
+            aggregate_fns["sample"] = sample_mean_sd
 
     @experiment.named_config
     def large():

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -32,7 +32,8 @@ import sacred
 import scipy.stats
 from stable_baselines.common import vec_env
 
-from evaluating_rewards import rewards, serialize, tabular
+from evaluating_rewards import util
+from evaluating_rewards import rewards, serialize
 from evaluating_rewards.analysis import stylesheets, visualize
 from evaluating_rewards.analysis.dissimilarity_heatmaps import heatmaps, reward_masks
 
@@ -87,8 +88,8 @@ def load_models(
 
 def bootstrap_ci(vals: Iterable[float], n_bootstrap: int, alpha: float) -> Mapping[str, float]:
     """Compute `alpha` %ile confidence interval of mean of `vals` from `n_bootstrap` samples."""
-    bootstrapped = tabular.bootstrap(np.array(vals), stat_fn=np.mean, n_samples=n_bootstrap)
-    lower, middle, upper = tabular.empirical_ci(bootstrapped, alpha)
+    bootstrapped = util.bootstrap(np.array(vals), stat_fn=np.mean, n_samples=n_bootstrap)
+    lower, middle, upper = util.empirical_ci(bootstrapped, alpha)
     return {"lower": lower, "middle": middle, "upper": upper, "width": upper - lower}
 
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -94,8 +94,8 @@ def bootstrap_ci(vals: Iterable[float], n_bootstrap: int, alpha: float) -> Mappi
 
 def studentt_ci(vals: Sequence[float], alpha: float) -> Mapping[str, float]:
     """Compute `alpha` %ile confidence interval of mean of `vals` using t-distribution."""
+    assert len(vals) > 1
     df = len(vals) - 1
-    assert df > 0
     mu = np.mean(vals)
     stderr = scipy.stats.sem(vals)
     lower, upper = scipy.stats.t.interval(alpha / 100, df, loc=mu, scale=stderr)
@@ -193,7 +193,7 @@ def pretty_label_fstr(name: str) -> str:
 
 
 def multi_heatmaps(dissimilarities: Mapping[str, pd.Series], **kwargs) -> Mapping[str, plt.Figure]:
-    """Plot heatmap for each dissimilarity series in dissimilarities.
+    """Plot heatmap for each dissimilarity series in `dissimilarities`.
 
     Args:
         dissimilarities: Mapping from strings to dissimilarity matrix.
@@ -266,6 +266,9 @@ def make_config(
         - y_reward_cfgs (Iterable[RewardCfg]): tuples of reward_type and reward_path for y-axis.
         - log_root (str): the root directory to log; subdirectory path automatically constructed.
         - n_bootstrap (int): the number of bootstrap samples to take.
+        - alpha (float): percentile confidence interval
+        - aggregate_kinds (Iterable[str]): the type of aggregations to perform across seeds.
+            Not used in `plot_return_heatmap` which only supports its own kind of bootstrapping.
         - heatmap_kwargs (dict): passed through to `analysis.compact_heatmaps`.
         - styles (Iterable[str]): styles to apply from `evaluating_rewards.analysis.stylesheets`.
         - save_kwargs (dict): passed through to `analysis.save_figs`.

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -23,11 +23,12 @@ import os
 from typing import Iterable, Mapping, Tuple
 
 import gym
+import numpy as np
 import pandas as pd
 import sacred
 from stable_baselines.common import vec_env
 
-from evaluating_rewards import rewards, serialize
+from evaluating_rewards import rewards, serialize, tabular
 from evaluating_rewards.analysis.dissimilarity_heatmaps import heatmaps, reward_masks
 
 RewardCfg = Tuple[str, str]  # (type, path)
@@ -99,6 +100,12 @@ def dissimilarity_mapping_to_series(
         "source_reward_path",
     ]
     return dissimilarity
+
+
+def bootstrap_ci(vals: Iterable[float], n_bootstrap: int, alpha: float) -> Mapping[str, float]:
+    bootstrapped = tabular.bootstrap(np.array(vals), stat_fn=np.mean, n_samples=n_bootstrap)
+    lower, middle, upper = tabular.empirical_ci(bootstrapped, alpha)
+    return {"lower": lower, "middle": middle, "upper": upper}
 
 
 MUJOCO_STANDARD_ORDER = [

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -139,6 +139,7 @@ def make_config(
         - x_reward_cfgs (Iterable[RewardCfg]): tuples of reward_type and reward_path for x-axis.
         - y_reward_cfgs (Iterable[RewardCfg]): tuples of reward_type and reward_path for y-axis.
         - log_root (str): the root directory to log; subdirectory path automatically constructed.
+        - n_bootstrap (int): the number of bootstrap samples to take.
         - heatmap_kwargs (dict): passed through to `analysis.compact_heatmaps`.
         - styles (Iterable[str]): styles to apply from `evaluating_rewards.analysis.stylesheets`.
         - save_kwargs (dict): passed through to `analysis.save_figs`.
@@ -150,6 +151,8 @@ def make_config(
         env_name = "evaluating_rewards/PointMassLine-v0"
         kinds = POINT_MASS_KINDS
         log_root = serialize.get_output_dir()  # where results are read from/written to
+        n_bootstrap = 1000  # number of bootstrap samples
+        alpha = 95  # percentile confidence interval
 
         # Reward configurations: models to compare
         x_reward_cfgs = None

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -32,8 +32,7 @@ import sacred
 import scipy.stats
 from stable_baselines.common import vec_env
 
-from evaluating_rewards import util
-from evaluating_rewards import rewards, serialize
+from evaluating_rewards import rewards, serialize, util
 from evaluating_rewards.analysis import stylesheets, visualize
 from evaluating_rewards.analysis.dissimilarity_heatmaps import heatmaps, reward_masks
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/heatmaps.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/heatmaps.py
@@ -59,6 +59,7 @@ def comparison_heatmap(
     cmap: str = "GnBu",
     robust: bool = False,
     preserve_order: bool = False,
+    label_fstr: Optional[str] = None,
     normalize: bool = False,
     mask: Optional[pd.Series] = None,
     **kwargs,
@@ -80,6 +81,9 @@ def comparison_heatmap(
         preserve_order: If True, retains the same order as the input index
             after rewriting the index values for readability. If false,
             sorts the rewritten values alphabetically.
+        label_fstr: Format string to use for the label for the colorbar legend.` {args}` is
+            replaced with arguments to distance and `{transform_start}` and `{transform_end}`
+            is replaced with any transformations of the distance (e.g. log).
         normalize: If True, divides by distance from Zero reward to target, rescaling
             all values between 0 and 1. (Values may exceed 1 due to optimisation error.)
         mask: If provided, only display cells where mask is True.
@@ -99,10 +103,13 @@ def comparison_heatmap(
     annot = vals.applymap(fmt)
     cbar_kws = dict(cbar_kws or {})
 
-    label = r"D_{\mathrm{norm}}" if normalize else "D"
-    label += "(R_S, R_T)"
-    if log:
-        label = r"\log_{10}(" + label + ")"
+    if label_fstr is None:
+        label_fstr = "{transform_start}D({args}){transform_end}"
+    transform_start = r"\log_{10}(" if log else ""
+    transform_end = ")" if log else ""
+    label = label_fstr.format(
+        transform_start=transform_start, args="R_S,R_T", transform_end=transform_end
+    )
     cbar_kws.setdefault("label", f"${label}$")
 
     if robust:

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/heatmaps.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/heatmaps.py
@@ -105,8 +105,8 @@ def comparison_heatmap(
 
     if label_fstr is None:
         label_fstr = "{transform_start}D({args}){transform_end}"
-    transform_start = r"\log_{10}(" if log else ""
-    transform_end = ")" if log else ""
+    transform_start = r"\log_{10}\left(" if log else ""
+    transform_end = r"\right)" if log else ""
     label = label_fstr.format(
         transform_start=transform_start, args="R_S,R_T", transform_end=transform_end
     )

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -20,13 +20,11 @@ import os
 from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
 
 from imitation.util import util
-import matplotlib.pyplot as plt
 import numpy as np
 import sacred
 import tensorflow as tf
 
 from evaluating_rewards import canonical_sample, datasets, rewards, tabular
-from evaluating_rewards.analysis import stylesheets, visualize
 from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
 
@@ -324,7 +322,7 @@ def plot_canon_heatmap(
     log_dir: str,
     data_root: str,
     save_kwargs: Mapping[str, Any],
-) -> Mapping[str, plt.Figure]:
+) -> None:
     """Entry-point into script to produce divergence heatmaps.
 
     Args:
@@ -385,11 +383,7 @@ def plot_canon_heatmap(
         aggregated = cli_common.twod_mapping_to_multi_series(aggregated)
         vals.update({f"{name}_{k}": v for k, v in aggregated.items()})
 
-    with stylesheets.setup_styles(styles):
-        figs = cli_common.multi_heatmaps(vals, **heatmap_kwargs)
-        visualize.save_figs(log_dir, figs.items(), **save_kwargs)
-
-    return figs
+    cli_common.save_artifacts(vals, styles, log_dir, heatmap_kwargs, save_kwargs)
 
 
 if __name__ == "__main__":

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -27,7 +27,7 @@ import tensorflow as tf
 
 from evaluating_rewards import canonical_sample, datasets, rewards, tabular
 from evaluating_rewards.analysis import stylesheets, visualize
-from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common, heatmaps
+from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
 
 plot_canon_heatmap_ex = sacred.Experiment("plot_canon_heatmap")
@@ -378,15 +378,11 @@ def plot_canon_heatmap(
 
     aggregate_fn = functools.partial(cli_common.bootstrap_ci, n_bootstrap=n_bootstrap, alpha=alpha)
     aggregated = {k: aggregate_fn(v) for k, v in dissimilarities.items()}
-    keys = list(set((tuple(v.keys()) for v in aggregated.values())))
-    assert len(keys) == 1
-    vals = {outer_key: {k: v[outer_key] for k, v in aggregated.items()} for outer_key in keys[0]}
-    vals = {k: cli_common.dissimilarity_mapping_to_series(v) for k, v in vals.items()}
+    vals = cli_common.twod_mapping_to_multi_series(aggregated)
 
     with stylesheets.setup_styles(styles):
-        for name, val in vals.items():
-            figs = heatmaps.compact_heatmaps(dissimilarity=val, **heatmap_kwargs)
-            visualize.save_figs(os.path.join(log_dir, name), figs.items(), **save_kwargs)
+        figs = cli_common.multi_heatmaps(vals, **heatmap_kwargs)
+        visualize.save_figs(log_dir, figs.items(), **save_kwargs)
 
     return figs
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -24,8 +24,7 @@ import numpy as np
 import sacred
 import tensorflow as tf
 
-from evaluating_rewards import util
-from evaluating_rewards import canonical_sample, datasets, rewards, tabular
+from evaluating_rewards import canonical_sample, datasets, rewards, tabular, util
 from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -19,11 +19,12 @@ import logging
 import os
 from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
 
-from imitation.util import util
+from imitation.util import util as imit_util
 import numpy as np
 import sacred
 import tensorflow as tf
 
+from evaluating_rewards import util
 from evaluating_rewards import canonical_sample, datasets, rewards, tabular
 from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
@@ -86,7 +87,7 @@ def logging_config(
         computation_kind,
         distance_kind,
         f"discount{discount}",
-        util.make_unique_timestamp(),
+        imit_util.make_unique_timestamp(),
     )
 
 
@@ -232,7 +233,7 @@ def mesh_canon(
         distance_fn, discount=discount, deshape_fn=tabular.fully_connected_random_canonical_reward
     )
     logger.info("Computing distance")
-    return canonical_sample.cross_distance(x_rews, y_rews, distance_fn=distance_fn)
+    return util.cross_distance(x_rews, y_rews, distance_fn=distance_fn)
 
 
 def _direct_distance(rewa: np.ndarray, rewb: np.ndarray, p: int) -> float:
@@ -300,9 +301,7 @@ def sample_canon(
         raise ValueError(f"Unrecognized distance '{distance_kind}'")
 
     logger.info("Computing distance")
-    return canonical_sample.cross_distance(
-        x_deshaped_rew, y_deshaped_rew, distance_fn, parallelism=1,
-    )
+    return util.cross_distance(x_deshaped_rew, y_deshaped_rew, distance_fn, parallelism=1,)
 
 
 @plot_canon_heatmap_ex.main

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_canon_heatmap.py
@@ -96,9 +96,9 @@ def high_precision():
 
     Slow and not that much more informative so not worth it for exploratory data analysis.
     """
-    n_seeds = 10
-    n_samples = 16384
-    n_mean_samples = 16384
+    n_seeds = 30
+    n_samples = 32768
+    n_mean_samples = 32768
     n_bootstrap = 10000
     _ = locals()
     del _

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
@@ -27,7 +27,7 @@ from evaluating_rewards.analysis import results, stylesheets, visualize
 from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common, heatmaps
 from evaluating_rewards.scripts import script_utils
 
-logger = logging.getLogger("evaluating_rewards.analysis.dissimilarity_heatmaps.plot_epic_Heatmap")
+logger = logging.getLogger("evaluating_rewards.analysis.dissimilarity_heatmaps.plot_epic_heatmap")
 plot_epic_heatmap_ex = sacred.Experiment("plot_epic_heatmap")
 
 cli_common.make_config(plot_epic_heatmap_ex)

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
@@ -138,7 +138,7 @@ def plot_epic_heatmap(
     heatmap_kwargs: Mapping[str, Any],
     log_dir: str,
     save_kwargs: Mapping[str, Any],
-) -> Mapping[str, plt.Figure]:
+) -> None:
     """Entry-point into script to produce divergence heatmaps.
 
     Args:
@@ -197,10 +197,9 @@ def plot_epic_heatmap(
         figs = {}
         figs["loss"] = loss_heatmap(loss, res["loss"]["unwrapped_loss"])
         figs["affine"] = affine_heatmap(res["affine"]["scales"], res["affine"]["constants"])
-        figs.update(cli_common.multi_heatmaps(vals, **heatmap_kwargs))
         visualize.save_figs(log_dir, figs.items(), **save_kwargs)
 
-        return figs
+    cli_common.save_artifacts(vals, styles, log_dir, heatmap_kwargs, save_kwargs)
 
 
 if __name__ == "__main__":

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
@@ -81,6 +81,8 @@ def test():
         "evaluating_rewards/PointMassGroundTruth-v0",
         "evaluating_rewards/PointMassSparseWithCtrl-v0",
     ]
+    # Dummy test data only contains 1 seed so cannot use other methods.
+    aggregate_kinds = ("bootstrap",)
     # Do not include "tex" in styles here: this will break on CI.
     styles = ["paper", "heatmap-1col"]
     _ = locals()

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
@@ -181,9 +181,7 @@ def plot_epic_heatmap(
         figs = {}
         figs["loss"] = loss_heatmap(loss, res["loss"]["unwrapped_loss"])
         figs["affine"] = affine_heatmap(res["affine"]["scales"], res["affine"]["constants"])
-        for name, val in vals.items():
-            heatmap_figs = heatmaps.compact_heatmaps(dissimilarity=val, **heatmap_kwargs)
-            figs.update({f"{name}_{k}": v for k, v in heatmap_figs.items()})
+        figs.update(cli_common.multi_heatmaps(vals, **heatmap_kwargs))
         visualize.save_figs(log_dir, figs.items(), **save_kwargs)
 
         return figs

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
@@ -86,7 +86,6 @@ def paper():
         "sparse_penalty",
         "dirt_path",
         "cliff_walk",
-        "evaluating_rewards/Zero-v0",
     ]
     heatmap_kwargs = {  # noqa: F841  pylint:disable=unused-variable
         "order": reward_subset,

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
@@ -80,7 +80,7 @@ def high_precision():
 
     Slow and not that much more informative so not worth it for exploratory data analysis.
     """
-    n_episodes = 16384
+    n_episodes = 65536
     n_bootstrap = 10000
     _ = locals()
     del _
@@ -142,7 +142,7 @@ def correlation_distance(
     def ci_fn(rewa: np.ndarray, rewb: np.ndarray) -> Mapping[str, float]:
         distances = tabular.bootstrap(rewa, rewb, stat_fn=distance_fn, n_samples=n_bootstrap)
         lower, middle, upper = tabular.empirical_ci(distances, alpha)
-        return {"lower": lower, "middle": middle, "upper": upper}
+        return {"lower": lower, "middle": middle, "upper": upper, "width": upper - lower}
 
     logger.info("Computing distance")
     return canonical_sample.cross_distance(x_rets, y_rets, ci_fn, parallelism=1)

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
@@ -27,7 +27,7 @@ import tensorflow as tf
 
 from evaluating_rewards import canonical_sample, datasets, rewards, tabular
 from evaluating_rewards.analysis import stylesheets, visualize
-from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common, heatmaps
+from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
 
 plot_return_heatmap_ex = sacred.Experiment("plot_return_heatmap")
@@ -191,16 +191,11 @@ def plot_return_heatmap(
     aggregated = correlation_distance(  # pylint:disable=no-value-for-parameter
         sess, trajectories, models, x_reward_cfgs, y_reward_cfgs
     )
-    # TODO(adam): code duplication
-    keys = list(set((tuple(v.keys()) for v in aggregated.values())))
-    assert len(keys) == 1
-    vals = {outer_key: {k: v[outer_key] for k, v in aggregated.items()} for outer_key in keys[0]}
-    vals = {k: cli_common.dissimilarity_mapping_to_series(v) for k, v in vals.items()}
+    vals = cli_common.twod_mapping_to_multi_series(aggregated)
 
     with stylesheets.setup_styles(styles):
-        for name, val in vals.items():
-            figs = heatmaps.compact_heatmaps(dissimilarity=val, **heatmap_kwargs)
-            visualize.save_figs(os.path.join(log_dir, name), figs.items(), **save_kwargs)
+        figs = cli_common.multi_heatmaps(vals, **heatmap_kwargs)
+        visualize.save_figs(log_dir, figs.items(), **save_kwargs)
 
     return figs
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
@@ -24,8 +24,7 @@ import numpy as np
 import sacred
 import tensorflow as tf
 
-from evaluating_rewards import util
-from evaluating_rewards import datasets, rewards, tabular
+from evaluating_rewards import datasets, rewards, tabular, util
 from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
@@ -80,7 +80,7 @@ def high_precision():
 
     Slow and not that much more informative so not worth it for exploratory data analysis.
     """
-    n_episodes = 65536
+    n_episodes = 131072
     n_bootstrap = 10000
     _ = locals()
     del _

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
@@ -20,13 +20,11 @@ from typing import Any, Dict, Iterable, Mapping, Sequence, Tuple
 
 from imitation.data import types
 from imitation.util import util
-import matplotlib.pyplot as plt
 import numpy as np
 import sacred
 import tensorflow as tf
 
 from evaluating_rewards import canonical_sample, datasets, rewards, tabular
-from evaluating_rewards.analysis import stylesheets, visualize
 from evaluating_rewards.analysis.dissimilarity_heatmaps import cli_common
 from evaluating_rewards.scripts import script_utils
 
@@ -164,7 +162,7 @@ def plot_return_heatmap(
     log_dir: str,
     data_root: str,
     save_kwargs: Mapping[str, Any],
-) -> Mapping[str, plt.Figure]:
+) -> None:
     """Entry-point into script to produce divergence heatmaps.
 
     Args:
@@ -204,12 +202,7 @@ def plot_return_heatmap(
         sess, trajectories, models, x_reward_cfgs, y_reward_cfgs
     )
     vals = cli_common.twod_mapping_to_multi_series(aggregated)
-
-    with stylesheets.setup_styles(styles):
-        figs = cli_common.multi_heatmaps(vals, **heatmap_kwargs)
-        visualize.save_figs(log_dir, figs.items(), **save_kwargs)
-
-    return figs
+    cli_common.save_artifacts(vals, styles, log_dir, heatmap_kwargs, save_kwargs)
 
 
 if __name__ == "__main__":

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_return_heatmap.py
@@ -77,6 +77,18 @@ def logging_config(log_root, env_name, dataset_tag, corr_kind, discount):
 
 
 @plot_return_heatmap_ex.named_config
+def high_precision():
+    """Compute tight confidence intervals for publication quality figures.
+
+    Slow and not that much more informative so not worth it for exploratory data analysis.
+    """
+    n_episodes = 16384
+    n_bootstrap = 10000
+    _ = locals()
+    del _
+
+
+@plot_return_heatmap_ex.named_config
 def test():
     """Intended for debugging/unit test."""
     n_episodes = 64

--- a/src/evaluating_rewards/canonical_sample.py
+++ b/src/evaluating_rewards/canonical_sample.py
@@ -25,6 +25,7 @@ import tensorflow as tf
 from evaluating_rewards import datasets, rewards, tabular
 
 K = TypeVar("K")
+V = TypeVar("V")
 
 
 def _make_mesh_tensors(inputs: Mapping[K, np.ndarray]) -> Mapping[K, tf.Tensor]:
@@ -298,10 +299,10 @@ def sample_canon_shaping(
 def cross_distance(
     rewxs: Mapping[K, np.ndarray],
     rewys: Mapping[K, np.ndarray],
-    distance_fn: Callable[[np.ndarray, np.ndarray], float],
+    distance_fn: Callable[[np.ndarray, np.ndarray], V],
     parallelism: Optional[int] = None,
     threading: bool = True,
-) -> Mapping[Tuple[K, K], float]:
+) -> Mapping[Tuple[K, K], V]:
     """Helper function to compute distance between all pairs of rewards from `rewxs` and `rewys`.
 
     Args:

--- a/src/evaluating_rewards/tabular.py
+++ b/src/evaluating_rewards/tabular.py
@@ -24,7 +24,6 @@ import sklearn.utils
 from evaluating_rewards import rewards
 
 DeshapeFn = Callable[[np.ndarray, float], np.ndarray]
-DistanceFn = Callable[[np.ndarray, np.ndarray], float]
 
 
 def shape(reward: np.ndarray, potential: np.ndarray, discount: float) -> np.ndarray:
@@ -171,7 +170,7 @@ def _center(x: np.ndarray, weights: np.ndarray) -> np.ndarray:
 def bootstrap(
     *inputs, stat_fn, n_samples: int = 100, random_state: Optional[np.random.RandomState] = None
 ) -> np.ndarray:
-    """Evaluates stat_fn for n_samples of rewa and rewb with replacement.
+    """Evaluates stat_fn for n_samples from inputs with replacement.
 
     Args:
         inputs: The inputs to bootstrap over.
@@ -195,7 +194,7 @@ def bootstrap(
     return np.array(vals)
 
 
-def empirical_ci(arr: np.ndarray, alpha: float = 95) -> np.ndarray:
+def empirical_ci(arr: np.ndarray, alpha: float = 95.0) -> np.ndarray:
     """Computes percentile range in an array of values.
 
     Args:

--- a/src/evaluating_rewards/tabular.py
+++ b/src/evaluating_rewards/tabular.py
@@ -19,7 +19,6 @@ from typing import Callable, Optional, Tuple
 import numpy as np
 import pandas as pd
 import scipy.stats
-import sklearn.utils
 
 from evaluating_rewards import rewards
 
@@ -165,48 +164,6 @@ def epic_distance(
 def _center(x: np.ndarray, weights: np.ndarray) -> np.ndarray:
     mean = np.average(x, weights=weights)
     return x - mean
-
-
-def bootstrap(
-    *inputs, stat_fn, n_samples: int = 100, random_state: Optional[np.random.RandomState] = None
-) -> np.ndarray:
-    """Evaluates stat_fn for n_samples from inputs with replacement.
-
-    Args:
-        inputs: The inputs to bootstrap over.
-        stat_fn: A function computing a statistic on inputs.
-        n_samples: The number of bootstrapped samples to take.
-        random_state: Random state passed to `sklearn.utils.resample`.
-
-    Returns:
-        n_samples of the distance computed by `distance_fn`, each on an independent sample with
-        replacement from `rewa` and `rewb` of the same shape as `rewa` and `rewb`.
-    """
-    vals = []
-    for _ in range(n_samples):
-        samples = sklearn.utils.resample(*inputs, random_state=random_state)
-        if len(inputs) > 1:
-            val = stat_fn(*samples)
-        else:
-            val = stat_fn(samples)
-        vals.append(val)
-
-    return np.array(vals)
-
-
-def empirical_ci(arr: np.ndarray, alpha: float = 95.0) -> np.ndarray:
-    """Computes percentile range in an array of values.
-
-    Args:
-        arr: An array.
-        alpha: Percentile confidence interval.
-
-    Returns:
-        A triple of the lower bound, median and upper bound of the confidence interval
-        with a width of alpha.
-    """
-    percentiles = 50 - alpha / 2, 50, 50 + alpha / 2
-    return np.percentile(arr, percentiles)
 
 
 def pearson_distance(

--- a/src/evaluating_rewards/util.py
+++ b/src/evaluating_rewards/util.py
@@ -15,7 +15,7 @@
 """Miscellaneous helper methods."""
 
 import multiprocessing
-from typing import Optional, Mapping, Callable, Tuple, TypeVar
+from typing import Callable, Mapping, Optional, Tuple, TypeVar
 
 import numpy as np
 import sklearn.utils

--- a/src/evaluating_rewards/util.py
+++ b/src/evaluating_rewards/util.py
@@ -15,6 +15,7 @@
 """Miscellaneous helper methods."""
 
 import multiprocessing
+import multiprocessing.dummy
 from typing import Callable, Mapping, Optional, Tuple, TypeVar
 
 import numpy as np

--- a/src/evaluating_rewards/util.py
+++ b/src/evaluating_rewards/util.py
@@ -1,0 +1,106 @@
+# Copyright 2020 Adam Gleave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Miscellaneous helper methods."""
+
+import multiprocessing
+from typing import Optional, Mapping, Callable, Tuple, TypeVar
+
+import numpy as np
+import sklearn.utils
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def bootstrap(
+    *inputs, stat_fn, n_samples: int = 100, random_state: Optional[np.random.RandomState] = None
+) -> np.ndarray:
+    """Evaluates stat_fn for n_samples from inputs with replacement.
+
+    Args:
+        inputs: The inputs to bootstrap over.
+        stat_fn: A function computing a statistic on inputs.
+        n_samples: The number of bootstrapped samples to take.
+        random_state: Random state passed to `sklearn.utils.resample`.
+
+    Returns:
+        n_samples of the distance computed by `distance_fn`, each on an independent sample with
+        replacement from `rewa` and `rewb` of the same shape as `rewa` and `rewb`.
+    """
+    vals = []
+    for _ in range(n_samples):
+        samples = sklearn.utils.resample(*inputs, random_state=random_state)
+        if len(inputs) > 1:
+            val = stat_fn(*samples)
+        else:
+            val = stat_fn(samples)
+        vals.append(val)
+
+    return np.array(vals)
+
+
+def empirical_ci(arr: np.ndarray, alpha: float = 95.0) -> np.ndarray:
+    """Computes percentile range in an array of values.
+
+    Args:
+        arr: An array.
+        alpha: Percentile confidence interval.
+
+    Returns:
+        A triple of the lower bound, median and upper bound of the confidence interval
+        with a width of alpha.
+    """
+    percentiles = 50 - alpha / 2, 50, 50 + alpha / 2
+    return np.percentile(arr, percentiles)
+
+
+def cross_distance(
+    rewxs: Mapping[K, np.ndarray],
+    rewys: Mapping[K, np.ndarray],
+    distance_fn: Callable[[np.ndarray, np.ndarray], V],
+    parallelism: Optional[int] = None,
+    threading: bool = True,
+) -> Mapping[Tuple[K, K], V]:
+    """Helper function to compute distance between all pairs of rewards from `rewxs` and `rewys`.
+
+    Args:
+        rewxs: A mapping from keys to NumPy arrays of shape `(n,)`.
+        rewys: A mapping from keys to NumPy arrays of shape `(n,)`.
+        distance_fn: A function to compute the distance between two NumPy arrays.
+        parallelism: The number of threads/processes to execute in parallel; if not specified,
+            defaults to `multiprocessing.cpu_count()`.
+        threading: If true, use multi-threading; otherwise, use multiprocessing. For many NumPy
+            functions, multi-threading is higher performance since NumPy releases the GIL, and
+            threading avoids expensive copying of the arrays needed for multiprocessing.
+
+    Returns:
+        A mapping from (i,j) to `distance_fn(rews[i], rews[j])`.
+    """
+    shapes = set((v.shape for v in rewxs.values()))
+    shapes.update((v.shape for v in rewys.values()))
+    assert len(shapes) <= 1, "rewards differ in shape"
+
+    tasks = {(kx, ky): (rewx, rewy) for kx, rewx in rewxs.items() for ky, rewy in rewys.items()}
+
+    if parallelism == 1:
+        # Only one process? Skip multiprocessing, since creating Pool adds overhead.
+        results = [distance_fn(rewx, rewy) for rewx, rewy in tasks.values()]
+    else:
+        # We want parallelism, use multiprocessing to speed things up.
+        module = multiprocessing.dummy if threading else multiprocessing
+        with module.Pool(processes=parallelism) as pool:
+            results = pool.starmap(distance_fn, tasks.values())
+
+    return dict(zip(tasks.keys(), results))

--- a/tests/test_canonical_sample.py
+++ b/tests/test_canonical_sample.py
@@ -144,28 +144,3 @@ def test_sample_canon_shaping(
         p=1,
     )
     assert sparse_vs_gt > 0.1
-
-
-CROSS_DISTANCE_TEST_CASES = [
-    {"rewxs": {}, "rewys": {"bar": np.zeros(4)}, "expected": {}},
-    {
-        "rewxs": {"foo": np.zeros(4), 42: np.ones(4)},
-        "rewys": {"bar": np.zeros(4), None: np.ones(4)},
-        "expected": {("foo", "bar"): 0, ("foo", None): 1, (42, "bar"): 1, (42, None): 0},
-    },
-]
-
-
-@pytest.mark.parametrize("test_case", CROSS_DISTANCE_TEST_CASES)
-@pytest.mark.parametrize("threading", [False, True])
-@pytest.mark.parametrize("parallelism", [None, 1, 2])
-def test_cross_distance(test_case, parallelism: int, threading: bool) -> None:
-    """Tests canonical_sample.cross_distance on CROSS_DISTANCE_TEST_CASES."""
-    actual = canonical_sample.cross_distance(
-        test_case["rewxs"],
-        test_case["rewys"],
-        distance_fn=tabular.direct_distance,
-        parallelism=parallelism,
-        threading=threading,
-    )
-    assert test_case["expected"] == actual

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -32,12 +32,12 @@ from tests import common
 
 EXPERIMENTS = {
     # experiment, expected_type, extra_named_configs, config_updates
-    "plot_canon_heatmap": (plot_canon_heatmap.plot_canon_heatmap_ex, dict, [], {}),
-    "plot_epic_heatmap": (plot_epic_heatmap.plot_epic_heatmap_ex, dict, [], {}),
-    "plot_return_heatmap": (plot_return_heatmap.plot_return_heatmap_ex, dict, [], {}),
+    "plot_canon_heatmap": (plot_canon_heatmap.plot_canon_heatmap_ex, type(None), [], {}),
+    "plot_epic_heatmap": (plot_epic_heatmap.plot_epic_heatmap_ex, type(None), [], {}),
+    "plot_return_heatmap": (plot_return_heatmap.plot_return_heatmap_ex, type(None), [], {}),
     "plot_return_heatmap_spearman": (
         plot_return_heatmap.plot_return_heatmap_ex,
-        dict,
+        type(None),
         [],
         {"corr_kind": "spearman"},
     ),
@@ -62,7 +62,7 @@ def add_canon_experiments():
         for distance_kind in ["direct", "pearson"]:
             EXPERIMENTS[f"plot_canon_heatmap_{computation_kind}_{distance_kind}"] = (
                 plot_canon_heatmap.plot_canon_heatmap_ex,
-                dict,
+                type(None),
                 [],
                 {"computation_kind": computation_kind, "distance_kind": distance_kind},
             )
@@ -78,7 +78,7 @@ def add_canon_experiments():
     for name, named_configs in NAMED_CONFIGS.items():
         EXPERIMENTS[f"plot_canon_heatmap_{name}"] = (
             plot_canon_heatmap.plot_canon_heatmap_ex,
-            dict,
+            type(None),
             named_configs,
             {},
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,44 @@
+# Copyright 2020 Adam Gleave
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for evaluating_rewards.util."""
+
+import numpy as np
+import pytest
+
+from evaluating_rewards import tabular, util
+
+CROSS_DISTANCE_TEST_CASES = [
+    {"rewxs": {}, "rewys": {"bar": np.zeros(4)}, "expected": {}},
+    {
+        "rewxs": {"foo": np.zeros(4), 42: np.ones(4)},
+        "rewys": {"bar": np.zeros(4), None: np.ones(4)},
+        "expected": {("foo", "bar"): 0, ("foo", None): 1, (42, "bar"): 1, (42, None): 0},
+    },
+]
+
+
+@pytest.mark.parametrize("test_case", CROSS_DISTANCE_TEST_CASES)
+@pytest.mark.parametrize("threading", [False, True])
+@pytest.mark.parametrize("parallelism", [None, 1, 2])
+def test_cross_distance(test_case, parallelism: int, threading: bool) -> None:
+    """Tests canonical_sample.cross_distance on CROSS_DISTANCE_TEST_CASES."""
+    actual = util.cross_distance(
+        test_case["rewxs"],
+        test_case["rewys"],
+        distance_fn=tabular.direct_distance,
+        parallelism=parallelism,
+        threading=threading,
+    )
+    assert test_case["expected"] == actual


### PR DESCRIPTION
Compute confidence intervals using bootstrapping (all), and Student's t-distribution (CANON, EPIC). Also report sample mean and SD (CANON, EPIC) across seeds.

Visualized by saving multiple heatmaps, one for each type.