### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Data
+data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pylintrc
+++ b/pylintrc
@@ -15,6 +15,7 @@ disable=
 	duplicate-code,
 	# Python formatting cleaner, we don't care about minor performance overhead
 	logging-format-interpolation,
+	logging-fstring-interpolation,
 	# snake_case naming style: spurious errors for short variable names
 	C0103,
 	# hanging indent, see black GH issue #48 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ flake8-isort
 flaky
 hypothesis[numpy]
 isort
-pylint>=2.4,<2.5
+pylint>=2.6.0
 pytype
 pytest
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ pylint>=2.4,<2.5
 pytype
 pytest
 pytest-cov
-pytest-notebook
+# Switch back to PyPi once release >0.6.0 comes out
+pytest-notebook @ git+https://github.com/AdamGleave/pytest-notebook.git@pytest6-api-fix
 pytest-shard
 pytest-xdist

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,7 +13,7 @@ pylint>=2.4,<2.5
 pytype
 pytest
 pytest-cov
-# Switch back to PyPi once release >0.6.0 comes out
+# Switch back to PyPi once release containing https://github.com/chrisjsewell/pytest-notebook/pull/11 comes out
 pytest-notebook @ git+https://github.com/AdamGleave/pytest-notebook.git@pytest6-api-fix
 pytest-shard
 pytest-xdist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 seals @ git+https://github.com/HumanCompatibleAI/seals.git@a425714
-imitation @ git+https://github.com/HumanCompatibleAI/imitation.git@0173423
+imitation==0.1.1
 stable-baselines @ git+https://github.com/hill-a/stable-baselines.git
 gym[mujoco]
-matplotlib
+# Avoid https://github.com/matplotlib/matplotlib/issues/18407
+matplotlib!=3.3.1,!=3.3.0
 numpy
 pandas
 pymdptoolbox

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ def get_version() -> str:
     Changes system path internally to avoid missing dependencies breaking imports.
     """
     sys.path.insert(
-        0, os.path.join(os.path.dirname(__file__), "src", "evaluating_rewards"),
+        0,
+        os.path.join(os.path.dirname(__file__), "src", "evaluating_rewards"),
     )
     from version import (  # type:ignore  # pylint:disable=no-name-in-module,import-outside-toplevel
         VERSION,

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/cli_common.py
@@ -64,7 +64,9 @@ def canonicalize_reward_cfg(reward_cfg: RewardCfg, data_root: str) -> RewardCfg:
 
 
 def load_models(
-    env_name: str, reward_cfgs: Iterable[RewardCfg], discount: float,
+    env_name: str,
+    reward_cfgs: Iterable[RewardCfg],
+    discount: float,
 ) -> Mapping[RewardCfg, rewards.RewardModel]:
     """Load models specified by the `reward_cfgs`.
 
@@ -83,7 +85,11 @@ def load_models(
     }
 
 
-def relative_error(lower: float, mean: float, upper: float,) -> float:
+def relative_error(
+    lower: float,
+    mean: float,
+    upper: float,
+) -> float:
     """Compute relative upper bound rel, which the mean is within +/- rel % of.
 
     Since this may be asymmetric between lower and upper, returns the maximum of
@@ -169,7 +175,8 @@ def twod_mapping_to_multi_series(
 
 
 def apply_multi_aggregate_fns(
-    dissimilarities: Mapping[Any, Sequence[float]], aggregate_fns: Mapping[str, AggregateFn],
+    dissimilarities: Mapping[Any, Sequence[float]],
+    aggregate_fns: Mapping[str, AggregateFn],
 ) -> Mapping[str, pd.Series]:
     """Aggregate dissimilarities: e.g. confidence intervals.
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
@@ -299,7 +299,13 @@ def sample_canon(
     with sess.as_default():
         logger.info("Removing shaping")
         deshaped_rew = epic_sample.sample_canon_shaping(
-            models, batch, act_dist, obs_dist, n_mean_samples, discount, direct_p,
+            models,
+            batch,
+            act_dist,
+            obs_dist,
+            n_mean_samples,
+            discount,
+            direct_p,
         )
         x_deshaped_rew = {cfg: deshaped_rew[cfg] for cfg in x_reward_cfgs}
         y_deshaped_rew = {cfg: deshaped_rew[cfg] for cfg in y_reward_cfgs}

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_epic_heatmap.py
@@ -378,7 +378,7 @@ def compute_vals(
         logger.info(f"Seed {i}")
         with obs_sample_dist_factory(**sample_dist_factory_kwargs) as obs_dist:
             with act_sample_dist_factory(**sample_dist_factory_kwargs) as act_dist:
-                dissimilarity = computation_fn(
+                dissimilarity = computation_fn(  # pylint:disable=no-value-for-parameter
                     g, sess, obs_dist, act_dist, models, x_reward_cfgs, y_reward_cfgs
                 )
                 for k, v in dissimilarity.items():

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
@@ -200,7 +200,7 @@ def compute_divergence(reward_cfg: Dict[str, Any], discount: float, kind: str) -
                 canonical_kind = "_".join(kind.split("_")[:-1])
                 try:
                     deshape_fn = CANONICAL_DESHAPE_FN[canonical_kind]
-                except KeyError, e:
+                except KeyError as e:
                     raise ValueError(f"Invalid canonicalizer '{canonical_kind}'") from e
 
                 div = distance_fn(

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
@@ -98,7 +98,9 @@ def paper():
 @plot_gridworld_heatmap_ex.config
 def logging_config(log_root):
     log_dir = os.path.join(  # noqa: F841  pylint:disable=unused-variable
-        log_root, "plot_gridworld_divergence", util.make_unique_timestamp(),
+        log_root,
+        "plot_gridworld_divergence",
+        util.make_unique_timestamp(),
     )
 
 
@@ -238,7 +240,7 @@ def plot_gridworld_heatmap(
         discount: discount rate of MDP.
         log_dir: directory to write figures and other logging to.
         save_kwargs: passed through to `analysis.save_figs`.
-        """
+    """
     with stylesheets.setup_styles(styles):
         rewards = gridworld_rewards.REWARDS
         if reward_subset is not None:

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_gridworld_heatmap.py
@@ -200,8 +200,8 @@ def compute_divergence(reward_cfg: Dict[str, Any], discount: float, kind: str) -
                 canonical_kind = "_".join(kind.split("_")[:-1])
                 try:
                     deshape_fn = CANONICAL_DESHAPE_FN[canonical_kind]
-                except KeyError:
-                    raise ValueError(f"Invalid canonicalizer '{canonical_kind}'")
+                except KeyError, e:
+                    raise ValueError(f"Invalid canonicalizer '{canonical_kind}'") from e
 
                 div = distance_fn(
                     src_reward,

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_npec_heatmap.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/plot_npec_heatmap.py
@@ -54,7 +54,10 @@ def search_config(search, env_name):
 @plot_npec_heatmap_ex.config
 def logging_config(log_root, search):
     log_dir = os.path.join(  # noqa: F841  pylint:disable=unused-variable
-        log_root, "plot_epic_heatmap", str(search).replace("/", "_"), util.make_unique_timestamp(),
+        log_root,
+        "plot_epic_heatmap",
+        str(search).replace("/", "_"),
+        util.make_unique_timestamp(),
     )
 
 

--- a/src/evaluating_rewards/analysis/dissimilarity_heatmaps/table_combined.py
+++ b/src/evaluating_rewards/analysis/dissimilarity_heatmaps/table_combined.py
@@ -59,7 +59,10 @@ def default_config():
 def logging_config(log_root, tag):
     """Default logging configuration: hierarchical directory structure based on config."""
     log_dir = os.path.join(  # noqa: F841  pylint:disable=unused-variable
-        log_root, "table_combined", tag, imit_util.make_unique_timestamp(),
+        log_root,
+        "table_combined",
+        tag,
+        imit_util.make_unique_timestamp(),
     )
 
 

--- a/src/evaluating_rewards/analysis/results.py
+++ b/src/evaluating_rewards/analysis/results.py
@@ -176,7 +176,8 @@ def average_unwrapped_loss(stats: Stats) -> float:
 
 
 def loss_pipeline(
-    stats: ConfigStatsMapping, preprocess: Tuple[PreprocessFn] = (),
+    stats: ConfigStatsMapping,
+    preprocess: Tuple[PreprocessFn] = (),
 ):
     """Extract losses from stats and visualize in a heatmap."""
     loss = {cfg: average_loss(d) for cfg, d in stats.items()}
@@ -200,14 +201,17 @@ def get_affine_from_models(env_name: str, paths: Iterable[str]):
     with networks.make_session():
         for path in paths:
             model = serialize.load_reward(
-                "evaluating_rewards/RewardModel-v0", os.path.join(path, "model"), venv,
+                "evaluating_rewards/RewardModel-v0",
+                os.path.join(path, "model"),
+                venv,
             )
             return model.models["wrapped"][0].get_weights()
     return res
 
 
 def affine_pipeline(
-    stats: ConfigStatsMapping, preprocess: Tuple[PreprocessFn] = (),
+    stats: ConfigStatsMapping,
+    preprocess: Tuple[PreprocessFn] = (),
 ):
     """Extract final affine parameters from stats and visualize in a heatmap."""
     constants = get_metric(stats, "constant")

--- a/src/evaluating_rewards/analysis/reward_figures/gridworld_reward_heatmap.py
+++ b/src/evaluating_rewards/analysis/reward_figures/gridworld_reward_heatmap.py
@@ -234,7 +234,12 @@ def _reward_draw_spline(
         xy = xy + annot_padding * direction
     fontweight = "bold" if optimal else None
     ax.annotate(
-        text, xy=xy, ha="center", va="center_baseline", color=text_color, fontweight=fontweight,
+        text,
+        xy=xy,
+        ha="center",
+        va="center_baseline",
+        color=text_color,
+        fontweight=fontweight,
     )
 
     return vert, color, hatch_color

--- a/src/evaluating_rewards/analysis/reward_figures/plot_gridworld_reward.py
+++ b/src/evaluating_rewards/analysis/reward_figures/plot_gridworld_reward.py
@@ -64,7 +64,9 @@ def default_config():
 @plot_gridworld_reward_ex.config
 def logging_config(log_root, exp_name):
     log_dir = os.path.join(  # noqa: F841  pylint:disable=unused-variable
-        log_root, exp_name, util.make_unique_timestamp(),
+        log_root,
+        exp_name,
+        util.make_unique_timestamp(),
     )
 
 

--- a/src/evaluating_rewards/analysis/reward_figures/plot_pm_reward.py
+++ b/src/evaluating_rewards/analysis/reward_figures/plot_pm_reward.py
@@ -69,6 +69,7 @@ script_utils.add_logging_config(plot_pm_reward_ex, "plot_pm_reward")
 
 @plot_pm_reward_ex.config
 def logging_config(log_root, models, reward_type, reward_path):
+    """Default logging configuration."""
     data_root = os.path.join(log_root, "model_comparison")
     if models is None:
         log_dir = os.path.join(

--- a/src/evaluating_rewards/analysis/reward_figures/plot_pm_reward.py
+++ b/src/evaluating_rewards/analysis/reward_figures/plot_pm_reward.py
@@ -72,7 +72,9 @@ def logging_config(log_root, models, reward_type, reward_path):
     data_root = os.path.join(log_root, "model_comparison")
     if models is None:
         log_dir = os.path.join(
-            log_root, reward_type.replace("/", "_"), reward_path.replace("/", "_"),
+            log_root,
+            reward_type.replace("/", "_"),
+            reward_path.replace("/", "_"),
         )
     _ = locals()  # quieten flake8 unused variable warning
     del _

--- a/src/evaluating_rewards/analysis/stylesheets.py
+++ b/src/evaluating_rewards/analysis/stylesheets.py
@@ -103,7 +103,7 @@ STYLES = {
         "text.usetex": True,
         "pgf.texsystem": "pdflatex",
         "pgf.rcfonts": False,
-        "pgf.preamble": [r"\usepackage{figsymbols}", r"\usepackage{times}"],
+        "pgf.preamble": "\n".join([r"\usepackage{figsymbols}", r"\usepackage{times}"]),
     },
 }
 
@@ -122,14 +122,16 @@ def setup_styles(styles: Iterable[str]) -> Iterator[None]:
         and (if "tex" is one of the styles) the environment variable "TEXINPUTS" is set
         to support custom macros."""
     old_tex_inputs = os.environ.get("TEXINPUTS")
+    tainted = False
     try:
         if "tex" in styles:
             import matplotlib  # pylint:disable=import-outside-toplevel
 
             # PGF backend best for LaTeX. matplotlib probably already imported:
             # but should be able to switch as non-interactive.
-            matplotlib.use("pgf", warn=False, force=True)
+            matplotlib.use("pgf", force=True)
             os.environ["TEXINPUTS"] = LATEX_DIR + ":"
+            tainted = True
         styles = [STYLES[style] for style in styles]
 
         import matplotlib.pyplot as plt  # pylint:disable=import-outside-toplevel
@@ -137,7 +139,7 @@ def setup_styles(styles: Iterable[str]) -> Iterator[None]:
         with plt.style.context(styles):
             yield
     finally:
-        if "tex" in styles:
+        if tainted:
             if old_tex_inputs is None:
                 del os.environ["TEXINPUTS"]
             else:

--- a/src/evaluating_rewards/comparisons.py
+++ b/src/evaluating_rewards/comparisons.py
@@ -155,7 +155,10 @@ class RegressWrappedModel(RegressModel):
         return affine_model.fit_lstsq(batch, target=self.target, shaping=None)
 
     def fit(
-        self, dataset: datasets.TransitionsCallable, affine_size: Optional[int] = 4096, **kwargs,
+        self,
+        dataset: datasets.TransitionsCallable,
+        affine_size: Optional[int] = 4096,
+        **kwargs,
     ) -> FitStats:
         """Fits shaping to target.
 

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -62,7 +62,11 @@ def transitions_factory_iid_from_sample_dist(
         next_obses = obs_dist(total_timesteps)
         dones = np.zeros(total_timesteps, dtype=np.bool)
         return types.Transitions(
-            obs=np.array(obses), acts=np.array(acts), next_obs=np.array(next_obses), dones=dones,
+            obs=np.array(obses),
+            acts=np.array(acts),
+            next_obs=np.array(next_obses),
+            dones=dones,
+            infos=None,
         )
 
     yield f
@@ -199,7 +203,10 @@ def transitions_factory_from_random_model(
             next_obses.append(next_obs)
         dones = np.zeros(total_timesteps, dtype=np.bool)
         return types.Transitions(
-            obs=np.array(obses), acts=np.array(acts), next_obs=np.array(next_obses), dones=dones,
+            obs=np.array(obses),
+            acts=np.array(acts),
+            next_obs=np.array(next_obses),
+            dones=dones,
         )
 
     yield f

--- a/src/evaluating_rewards/datasets.py
+++ b/src/evaluating_rewards/datasets.py
@@ -207,6 +207,7 @@ def transitions_factory_from_random_model(
             acts=np.array(acts),
             next_obs=np.array(next_obses),
             dones=dones,
+            infos=None,
         )
 
     yield f

--- a/src/evaluating_rewards/envs/mujoco.py
+++ b/src/evaluating_rewards/envs/mujoco.py
@@ -51,8 +51,8 @@ class MujocoHardcodedReward(rewards.BasicRewardModel, serialize.LayersSerializab
     def __getattr__(self, name):
         try:
             return self._kwargs[name]
-        except KeyError:
-            raise AttributeError(f"Attribute '{name}' not present in self._kwargs")
+        except KeyError as e:
+            raise AttributeError(f"Attribute '{name}' not present in self._kwargs") from e
 
     @abc.abstractmethod
     def build_reward(self) -> tf.Tensor:

--- a/src/evaluating_rewards/envs/point_mass.py
+++ b/src/evaluating_rewards/envs/point_mass.py
@@ -248,7 +248,10 @@ class PointMassShaping(
     """Potential shaping term, based on distance to goal."""
 
     def __init__(
-        self, observation_space: gym.Space, action_space: gym.Space, discount: float = 1.0,
+        self,
+        observation_space: gym.Space,
+        action_space: gym.Space,
+        discount: float = 1.0,
     ):
         """Builds PointMassShaping.
 

--- a/src/evaluating_rewards/epic_sample.py
+++ b/src/evaluating_rewards/epic_sample.py
@@ -197,6 +197,7 @@ def sample_mean_rews(
             acts=act_tiled[: len(obs_repeated), :],
             next_obs=next_obs_tiled[: len(obs_repeated), :],
             dones=np.zeros(len(obs_repeated), dtype=np.bool),
+            infos=None,
         )
         rews = rewards.evaluate_models(models, batch)
         rews = {k: v.reshape(len(obs), -1) for k, v in rews.items()}

--- a/src/evaluating_rewards/experiments/monte_carlo.py
+++ b/src/evaluating_rewards/experiments/monte_carlo.py
@@ -102,7 +102,9 @@ class MonteCarloGreedyPolicy(policies.BasePolicy):
             next_obs = dup_obs
 
         dones = np.zeros(batch_size * self.n_samples, dtype=np.bool)
-        batch = types.Transitions(obs=dup_obs, acts=dup_actions, next_obs=next_obs, dones=dones)
+        batch = types.Transitions(
+            obs=dup_obs, acts=dup_actions, next_obs=next_obs, dones=dones, infos=None
+        )
         feed_dict = rewards.make_feed_dict([self.reward_model], batch)
         # TODO(): add a function to RewardModel to compute this?
         reward = self.sess.run(self.reward_model.reward, feed_dict=feed_dict)

--- a/src/evaluating_rewards/experiments/point_mass_analysis.py
+++ b/src/evaluating_rewards/experiments/point_mass_analysis.py
@@ -142,7 +142,7 @@ def mesh_input(
     next_obs = env.obs_from_state(next_states)
 
     dones = np.zeros(len(obs), dtype=np.bool)
-    dataset = types.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones)
+    dataset = types.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones, infos=None)
     return idxs, dataset
 
 

--- a/src/evaluating_rewards/preferences.py
+++ b/src/evaluating_rewards/preferences.py
@@ -310,7 +310,7 @@ class PreferenceComparisonTrainer:
         acts = _concatenate(preferences, "acts", slice(None))
         next_obs = _concatenate(preferences, "obs", slice(1, None))
         dones = np.zeros(len(obs), dtype=np.bool)
-        batch = types.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones)
+        batch = types.Transitions(obs=obs, acts=acts, next_obs=next_obs, dones=dones, infos=None)
         feed_dict = rewards.make_feed_dict([self.model], batch)
         labels = np.array([p.label for p in preferences])
         feed_dict[self._preference_labels] = labels

--- a/src/evaluating_rewards/preferences.py
+++ b/src/evaluating_rewards/preferences.py
@@ -75,7 +75,9 @@ def _slice_trajectory(trajectory: types.Trajectory, start: int, end: int) -> typ
     """Slice trajectory from timestep start to timestep end."""
     infos = trajectory.infos[start:end] if trajectory.infos is not None else None
     return types.Trajectory(
-        obs=trajectory.obs[start : end + 1], acts=trajectory.acts[start:end], infos=infos,
+        obs=trajectory.obs[start : end + 1],
+        acts=trajectory.acts[start:end],
+        infos=infos,
     )
 
 

--- a/src/evaluating_rewards/rewards.py
+++ b/src/evaluating_rewards/rewards.py
@@ -323,7 +323,12 @@ class MLPPotentialShaping(BasicRewardModel, PotentialShaping, serialize.LayersSe
         end_potential = ConstantLayer("end_potential")
         end_potential.build(())
         PotentialShaping.__init__(
-            self, old_potential, new_potential, end_potential.constant, self._proc_dones, discount,
+            self,
+            old_potential,
+            new_potential,
+            end_potential.constant,
+            self._proc_dones,
+            discount,
         )
 
         layers["end_potential"] = end_potential

--- a/src/evaluating_rewards/serialize.py
+++ b/src/evaluating_rewards/serialize.py
@@ -67,7 +67,11 @@ class RewardRegistry(registry.Registry[RewardLoaderFn]):
                     # TODO(adam): RewardFn should probably include dones?
                     dones = np.zeros(len(obs), dtype=np.bool)
                     transitions = types.Transitions(
-                        obs=obs, acts=actions, next_obs=next_obs, dones=dones
+                        obs=obs,
+                        acts=actions,
+                        next_obs=next_obs,
+                        dones=dones,
+                        infos=None,
                     )
                     fd = rewards.make_feed_dict([reward_model], transitions)
                     return sess.run(reward_model.reward, feed_dict=fd)

--- a/src/evaluating_rewards/serialize.py
+++ b/src/evaluating_rewards/serialize.py
@@ -135,7 +135,10 @@ reward_registry.register(
 
 
 def load_reward(
-    reward_type: str, reward_path: str, venv: vec_env.VecEnv, discount: Optional[float] = None,
+    reward_type: str,
+    reward_path: str,
+    venv: vec_env.VecEnv,
+    discount: Optional[float] = None,
 ) -> rewards.RewardModel:
     """Load serialized reward model.
 

--- a/src/evaluating_rewards/tabular.py
+++ b/src/evaluating_rewards/tabular.py
@@ -334,7 +334,9 @@ def fully_connected_random_canonical_reward(
 
 
 def fully_connected_greedy_canonical_reward(
-    rew: np.ndarray, discount: float, state_dist: Optional[np.ndarray] = None,
+    rew: np.ndarray,
+    discount: float,
+    state_dist: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """
     Compute version of rew with canonicalized shaping.

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,7 +58,9 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
-def combine_dicts(*dicts: Dict[str, Dict[K, V]],) -> Iterator[Tuple[str, Dict[K, V]]]:
+def combine_dicts(
+    *dicts: Dict[str, Dict[K, V]],
+) -> Iterator[Tuple[str, Dict[K, V]]]:
     """Return a generator merging together the dictionary arguments.
 
     Usage example:

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -22,7 +22,7 @@ from stable_baselines.common import vec_env
 import tensorflow as tf
 
 # Environments registered as a side-effect of importing
-from evaluating_rewards import comparisons, datasets, rewards, serialize
+from evaluating_rewards import comparisons, datasets, rewards, serialize # noqa: I001
 from evaluating_rewards import envs  # noqa: F401  pylint:disable=unused-import
 from tests import common
 

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -21,8 +21,7 @@ import pandas as pd
 from stable_baselines.common import vec_env
 import tensorflow as tf
 
-# Environments registered as a side-effect of importing
-from evaluating_rewards import comparisons, datasets, rewards, serialize # noqa: I001
+from evaluating_rewards import comparisons, datasets, rewards, serialize
 from evaluating_rewards import envs  # noqa: F401  pylint:disable=unused-import
 from tests import common
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -44,7 +44,9 @@ class TestEnvs:
     def test_premature_step(self, env):
         """Test that you must call reset() before calling step()."""
         seals_test.test_premature_step(
-            env, skip_fn=pytest.skip, raises_fn=pytest.raises,
+            env,
+            skip_fn=pytest.skip,
+            raises_fn=pytest.raises,
         )
 
     def test_rollout_schema(self, env):

--- a/tests/test_epic_sample.py
+++ b/tests/test_epic_sample.py
@@ -63,7 +63,11 @@ MESH_SPACES = [
 @pytest.mark.parametrize("space", MESH_SPACES)
 @pytest.mark.parametrize("n_models", range(3))
 def test_mesh_evaluate_models(
-    graph: tf.Graph, session: tf.Session, space: gym.Space, n_models: int, n_mesh: int = 64,
+    graph: tf.Graph,
+    session: tf.Session,
+    space: gym.Space,
+    n_models: int,
+    n_mesh: int = 64,
 ):
     """Checks `canonical_sample.mesh_evaluate_models` agrees with `mesh_evaluate_models_slow`."""
     with datasets.sample_dist_from_space(space) as dist:
@@ -89,7 +93,10 @@ def test_mesh_evaluate_models(
 
 @pytest.mark.parametrize("discount", [0.9, 0.99, 1.0])
 def test_sample_canon_shaping(
-    graph: tf.Graph, session: tf.Session, discount: float, eps: float = 1e-4,
+    graph: tf.Graph,
+    session: tf.Session,
+    discount: float,
+    eps: float = 1e-4,
 ):
     """Tests canonical_sample.sample_canon_shaping.
 
@@ -125,11 +132,18 @@ def test_sample_canon_shaping(
             ) as iid_generator:
                 batch = iid_generator(256)
     canon_rew = epic_sample.sample_canon_shaping(
-        models, batch, act_dist, obs_dist, n_mean_samples=256, discount=discount,
+        models,
+        batch,
+        act_dist,
+        obs_dist,
+        n_mean_samples=256,
+        discount=discount,
     )
 
     sparse_vs_affine = tabular.direct_distance(
-        canon_rew["evaluating_rewards/PointMassSparseWithCtrl-v0"], canon_rew["big_sparse"], p=1,
+        canon_rew["evaluating_rewards/PointMassSparseWithCtrl-v0"],
+        canon_rew["big_sparse"],
+        p=1,
     )
     assert sparse_vs_affine < eps
     sparse_vs_dense = tabular.direct_distance(

--- a/tests/test_epic_sample.py
+++ b/tests/test_epic_sample.py
@@ -47,7 +47,7 @@ def mesh_evaluate_models_slow(
     )
     dones = np.zeros(len(tiled_obs), dtype=np.bool)
     transitions = types.Transitions(
-        obs=tiled_obs, acts=tiled_acts, next_obs=tiled_next_obs, dones=dones
+        obs=tiled_obs, acts=tiled_acts, next_obs=tiled_next_obs, dones=dones, infos=None,
     )
     rews = rewards.evaluate_models(models, transitions)
     rews = {k: v.reshape(len(obs), len(actions), len(next_obs)) for k, v in rews.items()}

--- a/tests/test_epic_sample.py
+++ b/tests/test_epic_sample.py
@@ -47,7 +47,11 @@ def mesh_evaluate_models_slow(
     )
     dones = np.zeros(len(tiled_obs), dtype=np.bool)
     transitions = types.Transitions(
-        obs=tiled_obs, acts=tiled_acts, next_obs=tiled_next_obs, dones=dones, infos=None,
+        obs=tiled_obs,
+        acts=tiled_acts,
+        next_obs=tiled_next_obs,
+        dones=dones,
+        infos=None,
     )
     rews = rewards.evaluate_models(models, transitions)
     rews = {k: v.reshape(len(obs), len(actions), len(next_obs)) for k, v in rews.items()}

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -113,7 +113,9 @@ DISCOUNTS = [0.9, 0.99, 1.0]
 
 @pytest.fixture(name="helper_serialize_identity")
 def fixture_serialize_identity(
-    graph: tf.Graph, session: tf.Session, venv: vec_env.VecEnv,
+    graph: tf.Graph,
+    session: tf.Session,
+    venv: vec_env.VecEnv,
 ):
     """Creates reward model, saves it, reloads it, and checks for equality."""
 

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -46,7 +46,7 @@ def dummy_env_and_dataset(dims: int = 5):
         actions = np.array([act_space.sample() for _ in range(total_timesteps)])
         next_obs = (obs + actions).clip(0.0, 1.0)
         dones = np.zeros(total_timesteps, dtype=np.bool)
-        return types.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones)
+        return types.Transitions(obs=obs, acts=actions, next_obs=next_obs, dones=dones, infos=None)
 
     return {
         "observation_space": obs_space,


### PR DESCRIPTION
imitation to 0.1.1 -- support new types
matplotlib to 3.2.2; support >=3.2.2 as well, but blocked 3.2.1 and 3.2.0 due to a matplotlib bug.
black 20.8b1 (some minor formatting changes)
pylint 2.6: fixed some minor issues it detected; suppressed some warnings we don't care about mostly related to log format strings